### PR TITLE
🎨 Palette: Improve visual hierarchy of form actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-10-27 - Gradio Button Visual Hierarchy
+**Learning:** Default Gradio buttons within `gr.Row` appear identical, creating an ambiguous layout where destructive/secondary actions (like "Clear") hold the same visual weight as primary actions (like "Run"). This is especially problematic in side-by-side layouts.
+**Action:** Always assign `variant="primary"` to the main action button (e.g., "Run", "Authenticate", "Submit") when it is placed next to a secondary action button to establish clear visual hierarchy and prevent accidental clicks.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 **What**: Added `variant="primary"` to the main action buttons ("Run" and "Authenticate") in the Gradio web interface.
🎯 **Why**: In a side-by-side layout, default Gradio buttons look identical, making secondary actions ("Clear" or "Generate New Auth URL") hold the same visual weight as primary actions. This small visual tweak helps guide the user and prevent accidental destructive clicks.
📸 **Before/After**: The "Run" button and the "Authenticate" button now have a solid primary color background, clearly differentiating them from the adjacent secondary buttons.
♿ **Accessibility**: Improves visual focus and reduces cognitive load by establishing a clearer visual hierarchy of actions.

---
*PR created automatically by Jules for task [3395466392569770722](https://jules.google.com/task/3395466392569770722) started by @haseeb-heaven*