### PR TITLE
🎨 Palette: Add primary visual hierarchy to main buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-11 - Gradio Primary Button Visual Hierarchy
+**Learning:** In Gradio applications with multiple buttons in a row, users can accidentally click destructive or secondary actions (like "Clear" or "Regenerate") if all buttons look the same. Assigning `variant='primary'` to main action buttons (like "Run" or "Authenticate") establishes a clear visual hierarchy and prevents accidental clicks.
+**Action:** Always assign `variant='primary'` to the primary action button when it's placed near secondary buttons in Gradio interfaces.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", visible=False, variant="primary")
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
### 💡 What
Added `variant="primary"` to the main action buttons ("Authenticate" and "Run") in the Gradio interface.

### 🎯 Why
In Gradio applications with multiple buttons in a row, users can accidentally click destructive or secondary actions (like "Clear" or "Regenerate") if all buttons look the same. Assigning `variant='primary'` to main action buttons establishes a clear visual hierarchy and prevents accidental clicks. This also fulfills a finding documented in the Palette journal.

### 📸 Before/After
**Before:** "Authenticate" and "Generate New Auth URL" look identical. "Run" and "Clear" look identical.
**After:** "Authenticate" and "Run" have a distinct primary color, standing out from secondary options.

### ♿ Accessibility
Improves cognitive accessibility by providing clearer visual cues for the primary flow through the application.

---
*PR created automatically by Jules for task [8302615722164387245](https://jules.google.com/task/8302615722164387245) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added visual hierarchy guidelines for button styling in interfaces to reduce accidental clicks.
* **Style**
  * Updated authentication and main action buttons with primary styling for improved visual distinction.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/gworkspace-agent/pull/128)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->