### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection vulnerability in subprocess call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-12 - [HIGH] Command Injection vulnerability on Windows via shell=os.name == 'nt'
+**Vulnerability:** Found `subprocess.run(..., shell=os.name == 'nt')` being used with a list of arguments (`cmd`). Passing `shell=True` (which evaluates to True on Windows) with a list of arguments does not completely prevent shell injection on Windows because the shell still interprets some metacharacters, unlike POSIX.
+**Learning:** Using `shell=True` on Windows with a list in `subprocess` is insecure and can still lead to command injection.
+**Prevention:** Always use `shell=False` (which is the default) in `subprocess` calls unless specifically required for shell features, and ensure user inputs are sanitized if `shell=True` must be used.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `subprocess.run` was called with `shell=os.name == "nt"` and a list argument (`cmd`). On Windows, this evaluated to `shell=True`, and even with a list argument, the Windows shell (`cmd.exe`) may still interpret metacharacters, leading to potential command injection.
🎯 Impact: An attacker could potentially inject arbitrary commands if any part of the `marker_expr` (such as the `self.service` value) is user-controlled.
🔧 Fix: Removed `shell=os.name == "nt"` and hardcoded `shell=False`. Since `sys.executable` and `pytest` are invoked safely via absolute path, a shell is not required. Also documented the learning in `.jules/sentinel.md`.
✅ Verification: Ran `bandit` which no longer reports `subprocess call with shell=True identified, security issue` and verified `pytest` still runs correctly.

---
*PR created automatically by Jules for task [16461571335714901850](https://jules.google.com/task/16461571335714901850) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security guidelines detailing command injection vulnerability scenarios and recommended mitigation strategies.

* **Bug Fixes**
  * Enhanced test execution security across all platforms through improved subprocess handling to mitigate potential injection risks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/gworkspace-agent/pull/131)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->