### PR TITLE
🎨 Palette: Add primary variant to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Primary Buttons Visual Hierarchy
+**Learning:** In Gradio interfaces, when primary action buttons ('Run', 'Authenticate') are placed next to secondary buttons ('Clear', 'Generate New Auth URL'), they lack visual prominence, making it harder for users to identify the primary call to action quickly and increasing the risk of accidental clicks.
+**Action:** Always assign `variant='primary'` to main action buttons to establish clear visual hierarchy.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
**💡 What:** 
Added `variant="primary"` to the "Authenticate" and "Run" buttons in the Gradio web interface (`gws_assistant/gradio_app.py`). Also recorded a critical learning in `.jules/palette.md` to ensure future Gradio interfaces establish a clear visual hierarchy.

**🎯 Why:**
In the previous state, the primary call-to-action buttons ("Authenticate" and "Run") looked identical to secondary buttons like "Generate New Auth URL" and "Clear", failing to draw the user's attention. By leveraging the primary variant styling built into Gradio, it's easier for users to identify the main path forward and reduces cognitive load and the potential for accidental misclicks. 

**📸 Before/After:**
*(Visual Change - Text description for reviewers)*
Before: All buttons were standard gray/default styled.
After: "Authenticate" and "Run" buttons now feature a distinct primary background color (often blue/accent colored depending on the Gradio theme), making them stand out compared to the secondary actions next to them.

**♿ Accessibility:**
Improves cognitive accessibility by visually separating distinct levels of actions, allowing users who rely on visual cues or have cognitive impairments to find the expected next action more efficiently.

---
*PR created automatically by Jules for task [1646277282838012584](https://jules.google.com/task/1646277282838012584) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on UI visual-hierarchy standards for button styling in interfaces.

* **Style**
  * Updated main action button styling to improve visual prominence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/gworkspace-agent/pull/134)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->