### PR TITLE
🎨 Palette: Improve visual hierarchy of main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Improve visual hierarchy of main action buttons
+**Learning:** In Gradio interfaces, when placing main action buttons (like "Run" or "Authenticate") next to secondary ones (like "Clear"), it's crucial to explicitly assign `variant='primary'` to establish clear visual hierarchy. Otherwise, all buttons look the same, making the primary action ambiguous and increasing the chance of accidental clicks on the secondary action.
+**Action:** Always assign `variant='primary'` to main action buttons in Gradio when they are grouped with secondary buttons.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
### 💡 What
Added `variant="primary"` to the "Authenticate" and "Run" buttons in the Gradio app (`gws_assistant/gradio_app.py`). Updated the `.jules/palette.md` journal with a new entry on the importance of visual hierarchy in Gradio.

### 🎯 Why
When placing main action buttons next to secondary ones, it's crucial to explicitly establish a clear visual hierarchy. Without this, all buttons look the same, making the primary action ambiguous and increasing the chance of accidental clicks on secondary actions (like clicking "Clear" instead of "Run").

### 📸 Before/After
**Before:** All buttons had the same visual weight.
**After:** "Authenticate" and "Run" are now prominent, guiding the user's focus to the primary actions.

### ♿ Accessibility
Improves cognitive accessibility by clearly indicating the primary path forward for users, reducing cognitive load and the likelihood of errors.

---
*PR created automatically by Jules for task [1834998987165580202](https://jules.google.com/task/1834998987165580202) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Improvements**
  * Updated styling for "Authenticate" and "Run" action buttons to improve visual distinction in the interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/gworkspace-agent/pull/136)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->