### PR TITLE
🎨 Palette: [UX improvement] Add primary variant to main Gradio buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Visual Hierarchy in Gradio Forms
+**Learning:** When primary actions (like "Run" or "Authenticate") are placed next to secondary actions (like "Clear" or "Regenerate URL") in Gradio without clear visual distinction, users can accidentally click the wrong button, leading to destructive or frustrating outcomes. Setting `variant="primary"` on the main action establishes a clear visual hierarchy.
+**Action:** Always assign `variant='primary'` to main action buttons in Gradio interfaces when placed adjacent to secondary actions.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
## 💡 What
Added `variant="primary"` to the "Authenticate" and "Run" buttons in the Gradio interface (`gws_assistant/gradio_app.py`).

## 🎯 Why
Primary actions ("Run" and "Authenticate") were placed adjacent to secondary actions ("Clear" and "Generate New Auth URL") without clear visual distinction. This lack of visual hierarchy increased the risk of users accidentally clicking the wrong button, potentially causing destructive or frustrating outcomes.

## 📸 Before/After
Before: All buttons had the same secondary (default) visual styling.
After: "Run" and "Authenticate" buttons have a distinct, primary styling that draws the user's attention.

## ♿ Accessibility
Improves usability by establishing a clear visual hierarchy and reducing the cognitive load required to distinguish primary actions from secondary ones, minimizing accidental clicks.

---
*PR created automatically by Jules for task [816452034797940230](https://jules.google.com/task/816452034797940230) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Applied primary styling to action buttons for improved visual hierarchy, making it easier to identify main actions alongside secondary options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/gworkspace-agent/pull/137)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->