### PR TITLE
🎨 Palette: [UX improvement] Add primary variant to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-17 - Button hierarchy in Gradio app
+**Learning:** UX coding convention dictates using `variant='primary'` to main action buttons (e.g., 'Run', 'Authenticate') when they are placed near secondary buttons to establish clear visual hierarchy and prevent accidental clicks.
+**Action:** When working on Gradio apps, make sure main actions like 'Submit', 'Run', or 'Authenticate' are visually distinguished from secondary actions like 'Clear' or 'Cancel'.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", visible=False, variant="primary")
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant='primary'` to the main action buttons (`Run` and `Authenticate`) in the Gradio interface.
🎯 Why: To establish a clear visual hierarchy between primary actions and secondary actions (like `Clear`), preventing accidental clicks and making the interface more intuitive.
📸 Before/After: N/A (Gradio UI style change)
♿ Accessibility: Improves visual clarity and helps users identify primary actions more easily.

---
*PR created automatically by Jules for task [3596117789002923789](https://jules.google.com/task/3596117789002923789) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button styling to improve visual clarity and hierarchy. The "Authenticate" and "Run" buttons now display with enhanced visual prominence to clearly indicate they are primary actions, helping users more easily identify the main operations available in the interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/gworkspace-agent/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->