### PR TITLE
🛡️ Sentinel: [High] Fix subprocess shell injection vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-17 - [Subprocess Shell Injection on Windows]
+**Vulnerability:** `subprocess.run` called with `shell=os.name == 'nt'` and a list of arguments.
+**Learning:** On Windows, using `shell=True` with a list of arguments still triggers shell interpretation of metacharacters, potentially leading to shell injection.
+**Prevention:** Avoid using `shell=True` in `subprocess` calls when executing scripts or modules. Pass a list of arguments and set `shell=False` (default).

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,9 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # 🛡️ Sentinel: Fix potential shell injection by removing shell=True
+                # Using shell=True with a list of arguments on Windows still triggers shell interpretation
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Potential Subprocess Shell Injection. The `subprocess.run` function was called with `shell=os.name == "nt"` and a list of arguments. On Windows, using `shell=True` with a list of arguments still triggers shell interpretation of metacharacters, potentially leading to shell injection.
🎯 **Impact**: An attacker who can control elements of the command array might be able to inject shell commands on Windows environments, potentially leading to arbitrary code execution.
🔧 **Fix**: Removed the conditional `shell=True` parameter and allowed it to default to `False`. The command is explicitly invoking `sys.executable` (the Python binary), which does not require a shell to run. Also added a security comment explaining the fix.
✅ **Verification**:
- `bandit -c .bandit -r .` confirms the high-severity `B602` warning is resolved.
- Ran tests via `pytest tests/ -m 'not live_integration and not manual' --ignore=tests/manual --ignore=tests/test_live_integration.py` to ensure no functionality is broken.
- `ruff check framework/task_runner.py` passed successfully.
- Added an entry to `.jules/sentinel.md` noting the critical learning about `shell=True` on Windows.

---
*PR created automatically by Jules for task [1029995845796454138](https://jules.google.com/task/1029995845796454138) started by @haseeb-heaven*