### PR TITLE
🎨 Palette: Add primary visual variant to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - Visual Hierarchy in Gradio Buttons
+**Learning:** When building Gradio interfaces, it's crucial to establish a clear visual hierarchy between primary actions and secondary buttons to prevent accidental clicks. Main action buttons (like "Run" or "Authenticate") should stand out.
+**Action:** Always assign `variant='primary'` to main action buttons when they are placed near secondary buttons.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", visible=False, variant="primary")
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
### What
Added `variant="primary"` to the main action buttons ("Authenticate" and "Run") in the Gradio interface (`gws_assistant/gradio_app.py`). Created the `.jules/palette.md` journal to log this UX pattern.

### Why
In Gradio, all buttons default to a secondary visual style. When placed next to other buttons (like "Generate New Auth URL" or "Clear"), it lacks clear visual hierarchy, which can lead to accidental clicks or cognitive load in determining the primary action. 

### Before/After
*   **Before:** "Run" and "Clear" look identical. "Authenticate" and "Generate New Auth URL" look identical.
*   **After:** "Run" and "Authenticate" stand out visually as the primary actions for their respective sections.

### Accessibility
By establishing a clear visual hierarchy, it reduces cognitive load and makes the interface more intuitive for users navigating the application visually.

---
*PR created automatically by Jules for task [16514194697273803587](https://jules.google.com/task/16514194697273803587) started by @haseeb-heaven*