### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-20 - [Fix Command Injection Vulnerability in Task Runner]
+**Vulnerability:** Found `shell=os.name == "nt"` in `subprocess.run` inside `framework/task_runner.py` (line 78). This is insecure since the command args are passed as a list, and `shell=True` on Windows will use the list as a command string and its arguments to the shell in an unsafe way, or just generally `shell=True` exposes command injection risks and is discouraged.
+**Learning:** `subprocess.run(cmd, shell=os.name == "nt")` is commonly misapplied thinking Windows needs `shell=True` to execute things, but this is only true for built-in shell commands (like `dir`), not `.exe` or executable scripts if passed securely via `cmd` array, or it's simply better to use `shell=False`.
+**Prevention:** Always use `shell=False` (the default) when using `subprocess.run` or `subprocess.Popen` with a list of arguments, even on Windows.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,8 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # nosec B603 - securely executing using argument list without shell
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Found `subprocess.run` using `shell=os.name == "nt"` which evaluates to `shell=True` on Windows. Passing a command list with `shell=True` exposes the execution to command injection vulnerabilities via shell metacharacters.
🎯 **Impact:** An attacker who can influence the command arguments could potentially execute arbitrary commands on the host operating system.
🔧 **Fix:** Changed the `shell` parameter to `False` (which is the safe default) in `framework/task_runner.py` line 78 and added `# nosec B603` to annotate that it is now safe. Also documented this pattern in `.jules/sentinel.md`.
✅ **Verification:** Ran `PYTHONPATH=. pytest tests/ -m 'not live_integration and not manual' --ignore=tests/manual --ignore=tests/test_live_integration.py`, which passed. Also ran `bandit -r .` and verified that the `subprocess_popen_with_shell_equals_true` issue has been successfully resolved for this file.

---
*PR created automatically by Jules for task [14741501149492975280](https://jules.google.com/task/14741501149492975280) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed a critical security vulnerability in command execution that could expose systems to command injection attacks. The fix enforces safer command execution practices consistently across all operating systems, eliminating platform-specific vulnerabilities and reducing potential attack vectors. This improvement strengthens the framework's security posture and protects user systems from exploitation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/gworkspace-agent/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->