### PR TITLE
🎨 Palette: Add visual hierarchy to primary Gradio buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-20 - Visual Hierarchy for Main Actions
+**Learning:** Gradio interfaces can look flat and ambiguous when multiple buttons are placed side-by-side (e.g., "Run" vs "Clear", "Authenticate" vs "Generate New Auth URL"). This causes hesitation and potential accidental clicks.
+**Action:** Always assign `variant='primary'` to main action buttons in Gradio to establish a clear visual hierarchy and guide the user to the expected primary action.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
### 💡 What
Added `variant="primary"` to the main action buttons (`submit_auth_button` and `run_button`) in the Gradio application interface.
Also created the required journal entry in `.jules/palette.md`.

### 🎯 Why
Gradio interfaces can look flat and ambiguous when multiple buttons are placed side-by-side (e.g., "Run" vs "Clear", "Authenticate" vs "Generate New Auth URL"). Assigning a primary variant to main action buttons establishes a clear visual hierarchy, prevents user hesitation, and reduces the chance of accidental clicks on secondary actions.

### 📸 Before/After
*(Visual change only observable in Gradio UI. The primary buttons now use the app's accent color instead of the default secondary gray.)*

### ♿ Accessibility
Improves cognitive accessibility by clearly distinguishing primary calls to action from secondary or destructive ones, making the interface more intuitive for all users.

---
*PR created automatically by Jules for task [5915892712968562517](https://jules.google.com/task/5915892712968562517) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved button styling to establish a clearer visual hierarchy. Main action buttons now feature primary styling to reduce visual ambiguity between actions and provide better guidance for user interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/gworkspace-agent/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->