### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-21 - [CRITICAL] Fix Command Injection Vulnerability in Task Runner
+**Vulnerability:** Use of `shell=os.name == "nt"` inside `subprocess.run` with a list of arguments in `framework/task_runner.py`.
+**Learning:** On Windows, `shell=True` with a list still triggers shell interpretation of metacharacters, leading to command injection vulnerabilities if an argument contains shell variables or separators.
+**Prevention:** Avoid using `shell=True` in `subprocess` calls. Always set `shell=False` (or rely on the default) when executing scripts or modules with a list of arguments.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Command Injection in `framework/task_runner.py` via `subprocess.run(..., shell=os.name == "nt")`
🎯 **Impact**: On Windows, setting `shell=True` when passing a list of arguments still causes the shell to evaluate the arguments. This allows arbitrary command execution if any argument (such as a pytest marker expression) contains shell metacharacters.
🔧 **Fix**: Changed `shell=os.name == "nt"` to `shell=False`. The arguments are safely passed as a list to `sys.executable` without shell processing.
✅ **Verification**: Ran the test suite locally (`pytest tests/test_runner.py`) and verified no regressions occurred.

---
*PR created automatically by Jules for task [3141997209298723706](https://jules.google.com/task/3141997209298723706) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical command injection vulnerability in the task runner that particularly affected Windows systems. The test execution mechanism now implements safer subprocess handling techniques to prevent potential command injection attacks and ensure consistent, secure behavior across all platforms. Important security guidance has been documented.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/gworkspace-agent/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->