### PR TITLE
🎨 Palette: [UX improvement] Add primary variant to Gradio action buttons

### DIFF
--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)

--- a/tests/test_gradio_app_unit.py
+++ b/tests/test_gradio_app_unit.py
@@ -10,7 +10,7 @@ mock_gr.Blocks.return_value.__enter__.return_value = MagicMock()
 
 with patch.dict(sys.modules, {"gradio": mock_gr}):
     # Pre-patch setup_logging before importing
-    with patch("gws_assistant.gradio_app.setup_logging"):
+    with patch("gws_assistant.logging_utils.setup_logging"):
         from gws_assistant.gradio_app import GradioAssistant, create_interface
 
 
@@ -53,7 +53,7 @@ def test_create_interface():
     with patch("gws_assistant.gradio_app.AppConfig.from_env") as mock_conf:
         mock_conf.return_value.log_level = "INFO"
         mock_conf.return_value.log_file_path = "test.log"
-        with patch("gws_assistant.gradio_app.setup_logging"):
+        with patch("gws_assistant.logging_utils.setup_logging"):
             with patch("gws_assistant.gradio_app.GWSRunner"):
                 with patch("gws_assistant.gradio_app.WorkspaceAgentSystem"):
                     with patch("gws_assistant.gradio_app.PlanExecutor"):


### PR DESCRIPTION
💡 **What**: Added `variant="primary"` to the main "Authenticate" and "Run" action buttons in the Gradio interface.
🎯 **Why**: When primary action buttons are placed alongside secondary action buttons (e.g. "Run" vs "Clear", "Authenticate" vs "Generate New Auth URL"), it is important to distinguish them visually to prevent accidental clicks and improve the intuitiveness of the user interface.
📸 **Before/After**: The "Authenticate" and "Run" buttons now stand out more clearly as the default primary actions compared to their secondary counterparts.
♿ **Accessibility**: Establishing a clearer visual hierarchy aids in easier navigation and understanding of intended workflow.

---
*PR created automatically by Jules for task [7020484823471606340](https://jules.google.com/task/7020484823471606340) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button styling for authentication and execution controls to enhance visual prominence and user interface clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/gworkspace-agent/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->