### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-24 - Avoid shell=True in Windows Subprocess
+**Vulnerability:** High severity command injection risk discovered in `framework/task_runner.py` where `subprocess.run()` was using `shell=os.name == "nt"` with a list of arguments.
+**Learning:** On Windows, using `shell=True` with a list argument still triggers shell interpretation of metacharacters, unlike POSIX systems. If any element of the list (like `self.service`) is untrusted, it can lead to command injection.
+**Prevention:** Always use `shell=False` (the default) when passing a list of arguments to `subprocess`, and avoid `shell=True` entirely unless explicitly necessary with a single string command and sanitized inputs.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,8 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # 🛡️ Sentinel: Removed shell=True (even on Windows) when passing a list argument to prevent command injection
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: In `framework/task_runner.py`, `subprocess.run` was executed with `shell=os.name == "nt"` when running `pytest` commands via a list argument (`cmd`). On Windows systems, setting `shell=True` when passing a list argument can still lead to command injection if elements in the list (such as `self.service`) are unescaped or untrusted, as Windows doesn't inherently parse list arguments safely like POSIX systems do without a shell.
🎯 **Impact**: If an attacker could control the `self.service` variable (or if it were manipulated via untrusted inputs during the test run logic), they could execute arbitrary commands on the system.
🔧 **Fix**: Removed `shell=True` (changed to `shell=False`) for `subprocess.run` in `framework/task_runner.py`, as the shell is not needed to execute `pytest` since `sys.executable` already provides the absolute path to the Python interpreter. Additionally, added an inline comment explaining the security concern. Logged the learning in `.jules/sentinel.md`.
✅ **Verification**: Verified using `bandit` scanner and ensured that `pytest` functionality isn't broken for normal unit testing locally.

---
*PR created automatically by Jules for task [14651572552735300973](https://jules.google.com/task/14651572552735300973) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Secured subprocess command execution to prevent potential injection vulnerabilities by standardizing command invocation behavior across platforms

* **Documentation**
  - Added security advisory documenting command injection risks in subprocess operations and recommended preventive measures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/gworkspace-agent/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->