### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Command Injection]
+**Vulnerability:** Use of `shell=os.name == "nt"` in `subprocess.run` with a list of arguments in `framework/task_runner.py`.
+**Learning:** Using `shell=True` with a list of arguments on Windows still triggers shell interpretation of metacharacters, leading to potential shell injection vulnerabilities.
+**Prevention:** Always use `shell=False` (or omit the argument) when passing a list of arguments to `subprocess` functions, even on Windows.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,8 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # SECURITY: Avoid shell=True to prevent shell injection vulnerabilities, especially on Windows where shell=True with a list triggers shell interpretation
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Use of `shell=os.name == "nt"` in `subprocess.run` with a list of arguments in `framework/task_runner.py`.
🎯 **Impact:** Using `shell=True` with a list of arguments on Windows still triggers shell interpretation of metacharacters, leading to potential shell injection vulnerabilities. An attacker could potentially execute arbitrary commands if they can control part of the command arguments.
🔧 **Fix:** Changed `shell=os.name == "nt"` to `shell=False` to ensure arguments are passed directly to the executable without shell interpretation. Added a comment explaining the security concern.
✅ **Verification:** Ran `bandit -r framework/task_runner.py` to confirm the vulnerability is resolved. Ran `pytest` to ensure tests still pass.

---
*PR created automatically by Jules for task [5138518276333855608](https://jules.google.com/task/5138518276333855608) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a command injection security vulnerability in test execution to prevent potential shell injection attacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/gworkspace-agent/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->