### PR TITLE
🎨 Palette: Improve visual hierarchy of primary buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [Visual Hierarchy in Gradio]
+**Learning:** Gradio buttons default to secondary styling, causing primary actions like 'Run' and 'Authenticate' to blend in with secondary actions like 'Clear' or 'Generate New Auth URL', leading to potential accidental clicks or a lack of clear direction for the user.
+**Action:** Always assign `variant='primary'` to main action buttons in Gradio interfaces when placed near secondary buttons to establish clear visual hierarchy.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant='primary'` to the "Run" and "Authenticate" buttons in the Gradio interface.
🎯 Why: These buttons represent the primary actions in their respective sections but were previously styled identically to secondary buttons (like "Clear" or "Generate New Auth URL"). Differentiating them provides better visual hierarchy and reduces cognitive load.
📸 Before/After: Before, all buttons had the default (secondary) grey styling. After, "Run" and "Authenticate" stand out with primary styling (typically orange/colored depending on theme).
♿ Accessibility: Enhances usability by providing clearer visual cues for the main path of interaction, especially helpful for users with cognitive or visual impairments relying on visual emphasis.

---
*PR created automatically by Jules for task [15827898993460157812](https://jules.google.com/task/15827898993460157812) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated visual hierarchy guidelines for Gradio button styling and primary action differentiation.

* **Style**
  * Primary action buttons now display with distinct visual styling for improved clarity and user differentiation. The Authenticate and Run buttons have been updated to use primary styling, making key actions more visually prominent and easier to identify in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->