### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix shell=True vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-31 - Fix shell=True vulnerability in subprocess
+**Vulnerability:** subprocess.run was called with shell=True when evaluating on Windows. Passing arguments as a list with shell=True triggers cmd.exe execution of arguments, allowing shell injection on Windows.
+**Learning:** Even when passing args as a list instead of a string, shell=True on Windows passes them to cmd.exe, opening up injection risks.
+**Prevention:** Avoid shell=True in subprocess unless strictly executing shell built-ins. Pass arguments as a list and use shell=False.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -37,8 +37,19 @@ class TaskRunner:
 
         # Check for environment auth failures first
         combined_output = result.stdout + result.stderr
-        if any(msg in combined_output for msg in ["missing field client_id", "Authentication failed", "insufficient authentication scopes", "403", "Permission denied"]):
-            framework_logger.warning("Auth not configured locally or scopes missing, skipping test to maintain CI progression")
+        if any(
+            msg in combined_output
+            for msg in [
+                "missing field client_id",
+                "Authentication failed",
+                "insufficient authentication scopes",
+                "403",
+                "Permission denied",
+            ]
+        ):
+            framework_logger.warning(
+                "Auth not configured locally or scopes missing, skipping test to maintain CI progression"
+            )
             pytest.skip("GWS Auth/Scopes not configured. Skipping active side-effect validation.")
         if "Only OpenRouter free models are supported" in result.stderr:
             framework_logger.warning("OpenRouter free-model environment is not configured, skipping active validation")
@@ -75,7 +86,8 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # Security: Avoid shell=True to prevent shell injection vulnerabilities on Windows.
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `subprocess.run` call in `framework/task_runner.py` was using `shell=os.name == "nt"`. On Windows, using `shell=True` even when passing arguments as a list causes `cmd.exe` to interpret metacharacters, opening the door for shell injection vulnerabilities.
🎯 Impact: If `sys.executable` or other arguments in `cmd` can be manipulated, arbitrary command execution could be achieved on Windows hosts.
🔧 Fix: Explicitly set `shell=False` for all platforms. Since `cmd` is already provided as a list of strings (`[sys.executable, "-m", "pytest", ...]`), a shell is entirely unnecessary for correct execution.
✅ Verification: Ran `bandit` security scanner, which verified that the warning B602 has been eliminated. The test suite also passes successfully without the shell layer.

---
*PR created automatically by Jules for task [14738616969932148477](https://jules.google.com/task/14738616969932148477) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Patched a security vulnerability in command execution on Windows platforms affecting test operations.
  * Improved safety of test execution across all operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->