### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix subprocess call with shell=True

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - Fix subprocess.run shell injection vulnerability
+**Vulnerability:** `subprocess.run` was called with `shell=os.name == "nt"` in `framework/task_runner.py`.
+**Learning:** Using `shell=True` with a list of arguments on Windows can lead to shell injection vulnerabilities, as the list might be interpreted by the shell in unsafe ways. Even when it is conditional (`os.name == "nt"`), it exposes Windows users to risks.
+**Prevention:** Always use `shell=False` when calling `subprocess.run` with a list of arguments, regardless of the operating system, to ensure arguments are passed safely without shell interpretation.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,8 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # Security: Avoid using shell=True to prevent shell injection vulnerabilities.
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `subprocess.run` was called with `shell=True` on Windows, creating a potential shell injection vulnerability.
🎯 Impact: Untrusted inputs could execute arbitrary commands in the shell on Windows environments.
🔧 Fix: Removed `shell=os.name == "nt"` and replaced it with `shell=False` to pass arguments safely as a list.
✅ Verification: Ran `pytest` to ensure tests pass and `bandit` to ensure the vulnerability is resolved.

---
*PR created automatically by Jules for task [4502411908011625476](https://jules.google.com/task/4502411908011625476) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed a shell injection vulnerability in test execution to enhance security across all platforms. The test runner now uses secure subprocess handling to prevent potential command injection attacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->