### PR TITLE
🛡️ Sentinel: [High] Fix subprocess call with shell=True

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-04 - subprocess call with shell=True identified
+**Vulnerability:** subprocess.run was called with `shell=os.name == "nt"` in `framework/task_runner.py`, which evaluates to `True` on Windows.
+**Learning:** Avoid using `shell=True` in `subprocess` calls, especially when passing a list of arguments. On Windows, `shell=True` with a list still triggers shell interpretation of metacharacters, leading to potential command injection.
+**Prevention:** Always set `shell=False` (or omit the parameter as it defaults to `False`) when executing scripts or modules via subprocess to prevent shell injection vulnerabilities.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -37,8 +37,19 @@ class TaskRunner:
 
         # Check for environment auth failures first
         combined_output = result.stdout + result.stderr
-        if any(msg in combined_output for msg in ["missing field client_id", "Authentication failed", "insufficient authentication scopes", "403", "Permission denied"]):
-            framework_logger.warning("Auth not configured locally or scopes missing, skipping test to maintain CI progression")
+        if any(
+            msg in combined_output
+            for msg in [
+                "missing field client_id",
+                "Authentication failed",
+                "insufficient authentication scopes",
+                "403",
+                "Permission denied",
+            ]
+        ):
+            framework_logger.warning(
+                "Auth not configured locally or scopes missing, skipping test to maintain CI progression"
+            )
             pytest.skip("GWS Auth/Scopes not configured. Skipping active side-effect validation.")
         if "Only OpenRouter free models are supported" in result.stderr:
             framework_logger.warning("OpenRouter free-model environment is not configured, skipping active validation")
@@ -75,7 +86,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: High
💡 Vulnerability: `subprocess.run` was called with `shell=True` conditionally on Windows, creating a potential command injection vector.
🎯 Impact: An attacker could potentially inject arbitrary commands if inputs passed to `subprocess.run` were tampered with or poorly sanitized.
🔧 Fix: Replaced `shell=os.name == "nt"` with `shell=False` in `framework/task_runner.py` to ensure shell interpretation is always disabled.
✅ Verification: Ran `pytest` suite and `bandit` security scans successfully to confirm functionality is intact and the vulnerability is resolved.

---
*PR created automatically by Jules for task [14223785471132706160](https://jules.google.com/task/14223785471132706160) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a command injection vulnerability in subprocess execution by ensuring the shell option is consistently disabled across all operating systems, improving system security.

* **Chores**
  * Updated security documentation with guidance on preventing vulnerable subprocess configurations and refactored authentication failure detection logic for better code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->