### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command Injection risk in subprocess call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-08 - Fixed Command Injection risk in subprocess.run
+**Vulnerability:** Used `shell=os.name == "nt"` with a list-based command (`cmd = [sys.executable, ...]`) inside `subprocess.run()`.
+**Learning:** Even though the command was passed as a list, setting `shell=True` on Windows triggers the system shell (`cmd.exe`), which parses arguments and interprets special characters differently, opening up a Command Injection vector.
+**Prevention:** Always use `shell=False` (the default) when executing scripts or modules via `subprocess`, regardless of the underlying OS, unless strictly running a shell-native built-in command and safely escaping strings.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `subprocess.run` call in `framework/task_runner.py` previously passed `shell=os.name == "nt"`, meaning on Windows platforms `shell=True` was invoked. This creates a command injection risk, as user inputs, arguments, or environment variables passed to shell contexts can be mishandled. Even with list-based arguments, Windows interprets some special characters incorrectly if `shell=True`.
🎯 Impact: A malicious actor who influences arguments or environment variables could inject arbitrary commands executing under the permissions of the application process.
🔧 Fix: Explicitly set `shell=False` in `subprocess.run` to ensure commands are executed securely and arguments are not interpreted by a system shell.
✅ Verification: Ran the bandit security scanner to confirm the fix of B602:subprocess_popen_with_shell_equals_true and executed the global pytest suite safely to ensure regressions weren't introduced.

---
*PR created automatically by Jules for task [12048142756741780880](https://jules.google.com/task/12048142756741780880) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subprocess handling for test execution with safer configuration across platforms.

* **Documentation**
  * Added security guidance on subprocess usage to prevent command injection risks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->