### PR TITLE
🎨 Palette: Establish button visual hierarchy

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Establish button visual hierarchy
+**Learning:** The Gradio interface default buttons lack visual distinction, leading to potential accidental clicks on secondary actions like "Clear" or "Generate New Auth URL". Applying the `variant='primary'` to main action buttons establishes a clearer visual hierarchy.
+**Action:** When building Gradio interfaces, always assign `variant='primary'` to main action buttons placed near secondary buttons.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to the "Authenticate" and "Run" buttons in the Gradio interface. Also created `.jules/palette.md` to log a UX learning regarding visual hierarchy.
🎯 Why: These are the primary actions in their respective sections, and they are placed next to secondary actions ("Generate New Auth URL" and "Clear"). Giving them a primary variant establishes clear visual hierarchy and prevents accidental clicks on destructive or secondary actions.
📸 Before/After: Visual update tested locally via Playwright screenshots. "Run" and "Authenticate" now appear visually distinct (orange) from secondary buttons (gray).
♿ Accessibility: Improves visual accessibility by providing better contrast and clearer indication of the primary action path.

---
*PR created automatically by Jules for task [804732786768346302](https://jules.google.com/task/804732786768346302) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Enhanced button styling to establish clearer visual hierarchy between primary and secondary actions in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->