### PR TITLE
🛡️ Sentinel: [HIGH] Fix subprocess shell injection risk

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-27 - Subprocess Shell Injection Vulnerability in Task Runner
+**Vulnerability:** Found `subprocess.run` called with `shell=os.name == "nt"` in `framework/task_runner.py` (Bandit B602).
+**Learning:** Using `shell=True` on Windows with lists of arguments is dangerous as Windows shell interprets the arguments, allowing metacharacters like `&` or `|` in variables like `marker_expr` to inject arbitrary commands.
+**Prevention:** Always use `shell=False` (default) when using `subprocess.run` with a list of arguments, even on Windows, unless explicitly needing a shell built-in like `dir` or `echo`.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,8 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # Security concern: shell=False prevents shell injection vulnerabilities (Bandit B602)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `subprocess.run` was called with `shell=os.name == "nt"` in `framework/task_runner.py`. On Windows, this translates to `shell=True`, which creates a command injection risk (Bandit B602) when variables like `marker_expr` contain user input or unescaped data.
🎯 Impact: Arbitrary command execution if parameters passed to `subprocess.run` can be manipulated (e.g., through metacharacters like `&` or `|` on Windows).
🔧 Fix: Set `shell=False` (the safe default) since we are already passing arguments as a list. `sys.executable` execution does not require a shell.
✅ Verification: `bandit -r . -f json -x tests` reports 0 HIGH/CRITICAL issues. Relevant local `pytest` tests confirm testing behavior is maintained.

---
*PR created automatically by Jules for task [4595733935063550555](https://jules.google.com/task/4595733935063550555) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subprocess execution security in the task runner.

* **Documentation**
  * Added security sentinel documentation for process execution safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->