### PR TITLE
🎨 Palette: Add primary variants to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-12 - Primary Action Button Variants
+**Learning:** Gradio interface layouts placing primary actions (like 'Authenticate' or 'Run') next to secondary actions (like 'Generate New Auth URL' or 'Clear') lack visual hierarchy by default.
+**Action:** Always assign `variant='primary'` to main action buttons when they are grouped with secondary buttons to establish clear visual distinction and prevent accidental destructive clicks.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to "Authenticate" and "Run" buttons in `gws_assistant/gradio_app.py` and created `.jules/palette.md` to document the learning.
🎯 Why: Establishes clear visual hierarchy and prevents accidental clicks on secondary buttons ("Generate New Auth URL" and "Clear").
📸 Before/After: Authenticate and Run buttons are now highlighted as primary actions (orange).
♿ Accessibility: Improves cognitive accessibility by clearly distinguishing primary actions from secondary ones, making the interface more intuitive to navigate.

---
*PR created automatically by Jules for task [12096118093643649619](https://jules.google.com/task/12096118093643649619) started by @haseeb-heaven*