### PR TITLE
🎨 Palette: Visual hierarchy for main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - [Clear Visual Hierarchy for Main Actions]
+**Learning:** [When secondary and primary buttons are adjacent (like Run/Clear or Auth/Regenerate), users need visual distinction to avoid accidental clicks.]
+**Action:** [Always apply variant='primary' to the primary action buttons in Gradio interfaces.]

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to the "Run" and "Authenticate" buttons in the Gradio UI.
🎯 Why: To establish clear visual hierarchy when primary actions are placed next to secondary actions (like "Clear" and "Generate New Auth URL"). This helps prevent accidental clicks and guides the user's focus.
📸 Before/After: Screenshots captured and visually verified using Playwright.
♿ Accessibility: Enhances usability by providing a stronger visual cue for the primary action.

---
*PR created automatically by Jules for task [17161603015126411282](https://jules.google.com/task/17161603015126411282) started by @haseeb-heaven*