### PR TITLE
🛡️ Sentinel: [HIGH] Fix shell injection vulnerability in subprocess call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-14 - Fix Shell Injection Vulnerability on Windows Subprocess Calls
+**Vulnerability:** Found `subprocess.run` called with `shell=os.name == "nt"` in `framework/task_runner.py`.
+**Learning:** Even when `cmd` is passed as a list, setting `shell=True` on Windows causes Python to convert the list to a string and execute it via `cmd.exe`. If the list contains user-controlled elements (like `marker_expr`), this allows shell injection of metacharacters (e.g. `&`, `|`).
+**Prevention:** Avoid `shell=True` (or conditional equivalents like `shell=os.name == "nt"`) entirely when passing lists to `subprocess`, and rely on default `shell=False` execution logic unless shell features are strictly required and input is sanitized.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,8 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # security improvement: ensure shell=False to prevent shell injection, even on Windows
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `subprocess.run` was called with `shell=os.name == "nt"`, which can lead to shell injection vulnerabilities on Windows.
🎯 Impact: An attacker could potentially inject arbitrary shell commands if they control the `cmd` list elements on Windows.
🔧 Fix: Explicitly set `shell=False` in the `subprocess.run` call.
✅ Verification: Ran `bandit` which confirmed the B602 issue is resolved, ran the `framework/task_runner.py` script manually, and successfully ran the full `pytest` test suite.

---
*PR created automatically by Jules for task [11777997343289703966](https://jules.google.com/task/11777997343289703966) started by @haseeb-heaven*