### PR TITLE
🎨 Palette: Add primary variants to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-15 - Visual Hierarchy in Gradio Layouts
+**Learning:** Gradio defaults all `gr.Button` components to a secondary styling variant, resulting in a lack of visual hierarchy when primary actions (like "Run" or "Authenticate") are placed adjacent to secondary actions (like "Clear"). This pattern in the application's forms increases the risk of accidental clicks.
+**Action:** Always assign `variant='primary'` to the primary action buttons in `gr.Row` layouts to establish clear visual distinction.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to the "Authenticate" and "Run" buttons in the Gradio interface.
🎯 Why: To establish clear visual hierarchy when primary actions are placed near secondary buttons, preventing accidental clicks.
📸 Before/After: Visual update tested via Playwright. Buttons are now visually distinct.
♿ Accessibility: Improves visual clarity and user guidance.

---
*PR created automatically by Jules for task [2018451222192006953](https://jules.google.com/task/2018451222192006953) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button styling for primary and secondary actions to enhance visual hierarchy and reduce accidental clicks.
  * Updated "Run" and authentication buttons to use proper primary styling for better clarity and user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->