### PR TITLE
🎨 Palette: Add visual hierarchy to primary action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-16 - Visual Hierarchy for Gradio Action Buttons
+**Learning:** In Gradio UIs, primary actions placed adjacent to secondary actions (like "Run" next to "Clear") lack visual hierarchy by default, increasing the risk of accidental clicks on destructive or secondary actions.
+**Action:** Always assign `variant='primary'` to the main action button in adjacent button groupings to establish clear visual dominance.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", visible=False, variant="primary")
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What:
Added `variant="primary"` to the main "Authenticate" and "Run" buttons in the Gradio UI.

🎯 Why:
When primary action buttons are placed immediately next to secondary or destructive actions (like "Clear" or "Generate New Auth URL"), they lack visual distinction by default. Adding a primary variant establishes clear visual hierarchy, guiding the user's eye to the main action and preventing accidental clicks on secondary buttons.

📸 Before/After:
Before: "Run" and "Clear" buttons looked identical.
After: "Run" stands out with a primary color, clearly indicating the main path forward.

♿ Accessibility:
Improves cognitive accessibility by providing stronger visual cues for the primary interactive elements, making the interface easier to scan and understand.

---
*PR created automatically by Jules for task [11239241298530283897](https://jules.google.com/task/11239241298530283897) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated primary action button styling to establish clearer visual distinction between main and secondary actions in the interface.

* **Documentation**
  * Added UI styling guidelines documenting button hierarchy best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->