### PR TITLE
🎨 Palette: Add primary visual hierarchy to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Primary action buttons in Gradio interfaces
+**Learning:** Gradio UI doesn't visually differentiate between primary and secondary actions by default, which can cause users to accidentally click secondary actions (like "Clear" instead of "Run").
+**Action:** Always assign `variant='primary'` to main action buttons when they are placed adjacent to secondary buttons to establish clear visual hierarchy.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to the "Authenticate" and "Run" buttons in the Gradio interface.
🎯 Why: To establish clear visual hierarchy and prevent users from accidentally clicking secondary actions like "Clear" or "Generate New Auth URL".
📸 Before/After: Verified visually via screenshot; main actions are now distinct from secondary actions.
♿ Accessibility: Improves visual accessibility by providing clear visual cues for primary calls to action.

---
*PR created automatically by Jules for task [9072634407547060069](https://jules.google.com/task/9072634407547060069) started by @haseeb-heaven*