### PR TITLE
⚡ Bolt: Use tuple with startswith for performance improvement

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - startswith with tuple
+**Learning:** Checking `startswith` or `endswith` against multiple strings can be significantly faster if we pass a tuple of strings directly to the method, since the tuple check is implemented in C and runs much faster than a generator expression using `any()`. However, the tuple must be a static literal to avoid the overhead of dynamically converting lists or generators. This optimization is particularly beneficial in hot loops like `verification_engine.py`'s drive ID checks.
+**Action:** Replace `any(val.startswith(prefix) for prefix in [...])` with `val.startswith((...))` where applicable, specifically in hot paths like validation methods.

--- a/gws_assistant/verification_engine.py
+++ b/gws_assistant/verification_engine.py
@@ -1676,7 +1676,8 @@ class VerificationEngine:
     def _is_valid_drive_id(cls, value: str) -> bool:
         val_str = str(value)
         # Allow internal placeholders and specific recognized prefixes
-        if any(val_str.startswith(prefix) for prefix in ["sheet-", "doc-", "folder-", "file-", "evt-", "sent-", "$", "{{"]):
+        # startswith with a tuple is implemented in C and evaluates faster
+        if val_str.startswith(("sheet-", "doc-", "folder-", "file-", "evt-", "sent-", "$", "{{")):
             return len(val_str) > 2
         # Regular Drive IDs are URL-safe base64 encoded (25-60 chars).
         # Allow: alphanumeric, hyphen, underscore, period, and equals padding.


### PR DESCRIPTION
💡 What: Replaced generator expression in `any(str.startswith)` with `str.startswith((...))` using a static tuple literal in `VerificationEngine._is_valid_drive_id()`, and added the relevant finding to `.jules/bolt.md`.
🎯 Why: Passing a tuple directly to `startswith` is implemented in C and evaluates significantly faster than executing a Python-level generator expression using `any()`.
📊 Impact: Reduces overhead in the hot-path `_is_valid_drive_id` validation loop, improving evaluation speed by avoiding Python-level loop overhead.
🔬 Measurement: Verified by running `tests/test_verification_engine_unit.py` and `test_verification_engine.py` successfully.

---
*PR created automatically by Jules for task [12134300883861356325](https://jules.google.com/task/12134300883861356325) started by @haseeb-heaven*