### PR TITLE
🎨 Palette: Add primary variants to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Gradio Button Visual Hierarchy
+**Learning:** In the Gradio app, primary action buttons ("Run", "Authenticate") were visually identical to secondary buttons ("Clear", "Generate New Auth URL"). This lack of hierarchy can cause accidental clicks on secondary actions.
+**Action:** Always assign `variant='primary'` to main action buttons when they are placed near secondary buttons to establish clear visual hierarchy in Gradio interfaces.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 **What:** Added `variant="primary"` to the "Run" and "Authenticate" buttons in the Gradio web UI.
🎯 **Why:** Established a clear visual hierarchy. Previously, the primary action buttons ("Run", "Authenticate") were visually identical to their secondary counterparts ("Clear", "Generate New Auth URL"), which could lead to accidental clicks or user confusion.
📸 **Before/After:** The "Run" and "Authenticate" buttons now have a distinct orange background, making them stand out as the primary actions.
♿ **Accessibility:** Enhances cognitive accessibility by making the intended path forward more obvious through distinct styling, reducing cognitive load for users trying to determine the primary action.

---
*PR created automatically by Jules for task [3965381855679213909](https://jules.google.com/task/3965381855679213909) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidelines for button visual hierarchy and primary action styling best practices

* **Style**
  * Enhanced visual differentiation for primary action buttons in the interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->