### PR TITLE
🎨 Palette: Add primary button variants for visual hierarchy

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-20 - Button Visual Hierarchy
+**Learning:** Using primary button variants (`variant="primary"`) for main actions ("Run", "Authenticate") clearly distinguishes them from secondary or reset actions placed adjacent to them (like "Clear" or "Generate New Auth URL"). This establishes visual hierarchy, making the UI more intuitive and reducing accidental clicks.
+**Action:** When adding related UI buttons in a single row, always use `variant='primary'` to emphasize the main positive action to guide the user flow.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to the "Authenticate" and "Run" Gradio buttons.

🎯 Why: To establish clear visual hierarchy when primary action buttons are placed alongside secondary/reset buttons (like "Clear" or "Generate New Auth URL"). This helps prevent accidental misclicks and guides the user flow intuitively.

📸 Before/After: Visual changes verified via Playwright screenshot locally.
Before: Both "Run" and "Clear" buttons had identical neutral styling.
After: "Run" is highlighted distinctly from the "Clear" button. Similarly, "Authenticate" stands out clearly next to "Generate New Auth URL".

♿ Accessibility: Improves visual accessibility by adding prominence to key actions, reducing cognitive load for users scanning the page.

---
*PR created automatically by Jules for task [6416776990582116074](https://jules.google.com/task/6416776990582116074) started by @haseeb-heaven*