### PR TITLE
🎨 Palette: Add primary variants to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-21 - Visual Hierarchy in Action Buttons
+**Learning:** Gradio interfaces lack clear visual distinction between primary and secondary actions by default, which can lead to accidental clicks on buttons like 'Clear' instead of 'Run'.
+**Action:** Always assign `variant='primary'` to main action buttons placed near secondary buttons to establish clear visual hierarchy.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to the "Run" and "Authenticate" buttons in the Gradio interface.
🎯 Why: To establish a clear visual hierarchy and prevent accidental clicks when primary actions are placed near secondary buttons (like "Clear" or "Generate New Auth URL").
📸 Before/After: Visual hierarchy is now apparent with primary buttons highlighted.
♿ Accessibility: Improves usability by guiding users to the most important actions on the screen more clearly.

---
*PR created automatically by Jules for task [16306791539064772375](https://jules.google.com/task/16306791539064772375) started by @haseeb-heaven*