### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection risk in task runner

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## YYYY-MM-DD - [Title]
+**Vulnerability:** [What you found]
+**Learning:** [Why it existed]
+**Prevention:** [How to avoid next time]

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,8 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # Security enhancement: shell=False prevents command injection vulnerabilities, especially on Windows where shell=True with a list triggers shell interpretation.
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `task_runner.py` module used `shell=os.name == "nt"` when executing test commands via `subprocess.run`. On Windows, passing `shell=True` (even with an array/list of arguments) can trigger unsafe shell interpretation of metacharacters, leading to arbitrary code execution/shell injection.
🎯 **Impact:** An attacker who can control input to the testing execution chain could potentially execute arbitrary shell commands on the host machine.
🔧 **Fix:** Changed `shell=os.name == "nt"` to `shell=False` across all platforms and added an inline comment explaining the security necessity. Python's default behavior handles cross-platform command execution safely without `shell=True`.
✅ **Verification:** Ran test suite to ensure no tests were broken and re-ran `bandit` to confirm that the `B602` high severity issue was resolved.

---
*PR created automatically by Jules for task [10779743333234555321](https://jules.google.com/task/10779743333234555321) started by @haseeb-heaven*