### PR TITLE
🎨 Palette: Assign primary variant to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,6 @@
+## 2024-05-15 - Initial Journal
+**Learning:** Initial Palette memory file created to track UX improvements.
+**Action:** Use this file to log critical UX/a11y learnings based on changes made.
+## 2024-05-15 - Primary Variants for Main Actions
+**Learning:** Placing secondary actions visually equal to primary actions leads to confusion and accidental clicks. Adding `variant="primary"` to main action buttons in Gradio establishes a clear visual hierarchy.
+**Action:** Always assign `variant="primary"` to the main submit or run buttons when they are adjacent to secondary buttons like 'Clear' or 'Regenerate'.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Assigned `variant="primary"` to the main 'Authenticate' and 'Run' buttons in the Gradio UI.
🎯 Why: To establish clear visual hierarchy, distinguishing main actions from secondary actions (like 'Clear' or 'Generate New Auth URL') and preventing accidental clicks.
📸 Before/After: Visual changes visually verified locally via Playwright screenshots. The primary buttons now stand out clearly in orange, whereas secondary remain standard styling.
♿ Accessibility: Better visual contrast and focus hierarchy for keyboard navigation.

---
*PR created automatically by Jules for task [6088536170149158503](https://jules.google.com/task/6088536170149158503) started by @haseeb-heaven*