### PR TITLE
🎨 Palette: Add primary button variants for visual hierarchy

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-24 - Visual Hierarchy in Gradio Buttons
+**Learning:** In Gradio interfaces, main action buttons like "Run" or "Authenticate" blend in with secondary buttons like "Clear" or "Generate New Auth URL", leading to a lack of visual hierarchy.
+**Action:** Always assign `variant='primary'` to main action buttons placed near secondary buttons to establish clear visual hierarchy and prevent accidental clicks.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Updated the 'Authenticate' and 'Run' buttons in the Gradio UI to use the 'primary' variant.
🎯 Why: To establish a clear visual hierarchy and prevent accidental clicks when primary actions are placed near secondary actions like 'Clear' or 'Generate New Auth URL'.
📸 Before/After: Verified via frontend screenshot generation.
♿ Accessibility: Improves cognitive accessibility by clearly distinguishing the primary call-to-action on the screen.

---
*PR created automatically by Jules for task [13157874034835225892](https://jules.google.com/task/13157874034835225892) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved visual hierarchy in the Gradio interface by highlighting primary actions.
  * “Run” and “Authenticate” now stand out more clearly alongside secondary controls.

* **Bug Fixes**
  * Updated the initial behavior of the “Authenticate” button so it follows the new interface presentation more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->