### PR TITLE
🛡️ Sentinel: [HIGH] Fix shell=True vulnerability in subprocess call

### DIFF
--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Conditional usage of `shell=True` (`shell=os.name == "nt"`) in `subprocess.run` which can lead to shell injection vulnerabilities on Windows.
🎯 Impact: Passing a list with `shell=True` on Windows triggers shell parsing, potentially allowing attackers to execute arbitrary shell commands if parts of the argument list are untrusted.
🔧 Fix: Disabled shell interpretation by explicitly setting `shell=False`.
✅ Verification: Reran `bandit` to ensure the high severity issue is resolved, and ran `pytest tests/test_runner.py` to ensure core functionality hasn't regressed.

---
*PR created automatically by Jules for task [16627908878464664308](https://jules.google.com/task/16627908878464664308) started by @haseeb-heaven*