### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection vulnerability in subprocess call

### DIFF
--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,9 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # Security note: shell=False prevents shell injection vulnerabilities,
+                # especially on Windows where shell=True with a list triggers shell interpretation.
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A `subprocess.run` call in `framework/task_runner.py` used `shell=os.name == "nt"`, meaning on Windows environments it would use `shell=True` even when a list of commands is passed. This is a well-known command injection vulnerability because Windows interprets list items differently when the shell is involved, creating a risk if arguments are not strictly sanitized.
🎯 Impact: Exploitation could allow arbitrary shell execution in Windows environments, putting the system at severe risk.
🔧 Fix: Updated the `subprocess.run` call to explicitly set `shell=False` for all operating systems.
✅ Verification: Tested via the local `pytest tests/ -m 'not live_integration and not manual' --ignore=tests/manual --ignore=tests/test_live_integration.py` suite. Ran `bandit -r .` to confirm the HIGH severity warning is removed.

---
*PR created automatically by Jules for task [2805125532651426903](https://jules.google.com/task/2805125532651426903) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Test commands now run without OS-dependent shell interpretation, improving consistency and reducing command-execution risk.
  * Test timeout and return-code handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->