### PR TITLE
⚡ Bolt: Optimize string prefix checks with tuple

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-06-12 - [Python Optimization]
+**Learning:** Using generator expressions like `any(val.startswith(prefix) for prefix in [...])` is significantly slower than passing a tuple directly to `startswith`, e.g., `val.startswith((...))`, because the tuple approach is implemented in C.
+**Action:** Always prefer `startswith(tuple)` over `any()` with `startswith` for static prefix lists to maximize performance.

--- a/gws_assistant/verification_engine.py
+++ b/gws_assistant/verification_engine.py
@@ -1676,7 +1676,8 @@ class VerificationEngine:
     def _is_valid_drive_id(cls, value: str) -> bool:
         val_str = str(value)
         # Allow internal placeholders and specific recognized prefixes
-        if any(val_str.startswith(prefix) for prefix in ["sheet-", "doc-", "folder-", "file-", "evt-", "sent-", "$", "{{"]):
+        # startswith with a tuple is implemented in C and evaluates faster
+        if val_str.startswith(("sheet-", "doc-", "folder-", "file-", "evt-", "sent-", "$", "{{")):
             return len(val_str) > 2
         # Regular Drive IDs are URL-safe base64 encoded (25-60 chars).
         # Allow: alphanumeric, hyphen, underscore, period, and equals padding.


### PR DESCRIPTION
💡 What: Replaced a generator expression (`any(val.startswith(...))`) with a direct tuple call (`val.startswith((...))`) in `_is_valid_drive_id` within `verification_engine.py`. Added a comment explaining the change.
🎯 Why: Passing a tuple to `startswith` is implemented natively in C, avoiding the overhead of python generator expressions, which is noticeably faster when checking against multiple prefixes continuously.
📊 Impact: This function is likely heavily used during drive ID validation; executing it natively reduces processing overhead directly and slightly decreases execution time.
🔬 Measurement: Verified functionality by running tests (`pytest tests/`). Execution correctness remains completely the same as before.

---
*PR created automatically by Jules for task [4343217291379973251](https://jules.google.com/task/4343217291379973251) started by @haseeb-heaven*