### PR TITLE
🎨 Palette: Add primary button variants

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-01 - Add Primary Button Variants
+**Learning:** Gradio UI doesn't provide visual distinction between primary and secondary actions by default, which can lead to accidental clicks on destructive or clear buttons when placed together.
+**Action:** Always assign `variant='primary'` to main action buttons (e.g., 'Run', 'Authenticate') when placed near secondary buttons to establish clear visual hierarchy.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to the "Authenticate" and "Run" buttons in the Gradio UI.
🎯 Why: To establish clear visual hierarchy between primary actions and secondary actions (like "Clear" or "Generate New Auth URL") to prevent accidental clicks.
📸 Before/After: Visual hierarchy is now distinct, drawing focus to primary actions.
♿ Accessibility: Improved cognitive accessibility by making the intended path clearer.

---
*PR created automatically by Jules for task [9113153329891503883](https://jules.google.com/task/9113153329891503883) started by @haseeb-heaven*