### PR TITLE
🎨 Palette: Add primary variants to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-26 - Visual Hierarchy with Primary Buttons
+**Learning:** Users can accidentally click secondary actions when main and secondary buttons have the same visual weight. Gradio defaults all buttons to the 'secondary' variant, making the UI less intuitive.
+**Action:** Always assign `variant='primary'` to main action buttons (e.g., 'Run', 'Authenticate') when placed near secondary buttons to establish clear visual hierarchy and prevent misclicks.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", visible=False, variant="primary")
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to the "Authenticate" and "Run" buttons in the Gradio web UI.
🎯 Why: To establish a clear visual hierarchy and prevent accidental clicks on secondary actions like "Clear" or "Generate New Auth URL".
📸 Before/After: Visual changes verified locally; main buttons now have distinct highlighting.
♿ Accessibility: Improves cognitive accessibility by clearly distinguishing primary actions from secondary/destructive actions.

---
*PR created automatically by Jules for task [10154701701107541972](https://jules.google.com/task/10154701701107541972) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated key action buttons to stand out more clearly, reducing the chance of misclicks between primary and secondary actions.
  * Improved the visual hierarchy of the authentication and run controls for a more consistent interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->