### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection risk in task runner

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-26 - [High] subprocess call with shell=True identified
+**Vulnerability:** Found `subprocess.run(..., shell=os.name == "nt")` with uncontrolled arguments in `framework/task_runner.py`.
+**Learning:** `shell=True` on Windows allows attackers to execute arbitrary shell commands if variables within the command string are not properly sanitized.
+**Prevention:** Avoid `shell=True` wherever possible. If it's used with `os.name == "nt"`, only do so if absolutely necessary and strictly sanitize inputs. The current script doesn't execute user inputs directly via this vector in a way that requires `shell=True`, so it can be safely removed or passed as `shell=False`.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
- 🚨 Severity: HIGH
- 💡 Vulnerability: `subprocess.run` was called with `shell=True` on Windows environments in `framework/task_runner.py`.
- 🎯 Impact: This could potentially lead to command injection if environment variables or input commands are ever poisoned, leading to unauthorized code execution.
- 🔧 Fix: Replaced `shell=os.name == "nt"` with `shell=False` to pass arguments safely as a list without shell expansion.
- ✅ Verification: Bandit report confirms no High severity vulnerabilities. Tests passed successfully.

---
*PR created automatically by Jules for task [14845532121286856543](https://jules.google.com/task/14845532121286856543) started by @haseeb-heaven*