### PR TITLE
⚡ Bolt: Optimize startswith/endswith checks with C-level tuples

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-27 - Tuple C-Level Evaluation for String Prefix/Suffix Checking
+**Learning:** Using Python's built-in `startswith()` and `endswith()` with a tuple of strings is evaluated in C and executes significantly faster than using a generator expression inside `any()`.
+**Action:** Prioritize passing static tuples to `startswith()`/`endswith()` instead of writing `any(s.startswith(p) for p in prefixes)`.

--- a/gws_assistant/execution/resolver.py
+++ b/gws_assistant/execution/resolver.py
@@ -575,7 +575,7 @@ class ResolverMixin:
 
                 # 2. If we resolved to a list, but we are a single-token placeholder
                 # (e.g. {{task-1.id}}), pick the first item.
-                singular_suffixes = [
+                singular_suffixes = (
                     ".id",
                     ".name",
                     ".url",
@@ -587,8 +587,9 @@ class ResolverMixin:
                     ".documentId",
                     ".fileId",
                     ".file_id",
-                ]
-                if isinstance(resolved, list) and resolved and any(path.endswith(s) for s in singular_suffixes):
+                )
+                # endswith with a tuple is implemented in C and evaluates faster
+                if isinstance(resolved, list) and resolved and path.endswith(singular_suffixes):
                     self.logger.debug(f"DEBUG: Smart-unwrapping list result for '{path}' to first item.")
                     # We have a list. Check if we need to do the folder heuristic.
                     # Since resolved is likely just strings here (e.g. ['folder_id', 'doc_id']),

--- a/gws_assistant/verification_engine.py
+++ b/gws_assistant/verification_engine.py
@@ -1676,7 +1676,8 @@ class VerificationEngine:
     def _is_valid_drive_id(cls, value: str) -> bool:
         val_str = str(value)
         # Allow internal placeholders and specific recognized prefixes
-        if any(val_str.startswith(prefix) for prefix in ["sheet-", "doc-", "folder-", "file-", "evt-", "sent-", "$", "{{"]):
+        # startswith with a tuple is implemented in C and evaluates faster
+        if val_str.startswith(("sheet-", "doc-", "folder-", "file-", "evt-", "sent-", "$", "{{")):
             return len(val_str) > 2
         # Regular Drive IDs are URL-safe base64 encoded (25-60 chars).
         # Allow: alphanumeric, hyphen, underscore, period, and equals padding.


### PR DESCRIPTION
💡 What: Replaced generator expressions using `any(...)` with static tuples passed to `startswith()` and `endswith()`.
🎯 Why: Generator expressions incur Python-level overhead on every iteration. Passing a static tuple directly to `startswith()` or `endswith()` leverages a highly optimized C implementation, reducing execution time on critical paths like string validation and resolution.
📊 Impact: Significantly faster execution of string prefix/suffix checking by avoiding generator and loop overhead, especially within loops.
🔬 Measurement: Observe CPU profiling metrics during test runs or large data validation workloads, noticing reduced time spent in string comparison primitives.

---
*PR created automatically by Jules for task [13161156034691413399](https://jules.google.com/task/13161156034691413399) started by @haseeb-heaven*