### PR TITLE
🛡️ Sentinel: [HIGH] Fix shell injection vulnerability in subprocess call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## YYYY-MM-DD - [Title]
+**Vulnerability:** [What you found]
+**Learning:** [Why it existed]
+**Prevention:** [How to avoid next time]

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `subprocess.run` command in `framework/task_runner.py` used `shell=os.name == "nt"`, which evaluates arguments through the shell on Windows, leading to potential shell injection vulnerabilities.
🎯 Impact: If user input were ever passed into `cmd` on a Windows environment, a malicious user could execute arbitrary shell commands on the host machine.
🔧 Fix: Replaced `shell=os.name == "nt"` with the secure default `shell=False` to prevent shell injection, as `cmd` is already passed as a list of arguments.
✅ Verification: Verified that `shell=False` is used, and the Bandit scanner no longer flags this line for `B602: subprocess_popen_with_shell_equals_true`.

---
*PR created automatically by Jules for task [15766311600862346271](https://jules.google.com/task/15766311600862346271) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new security follow-up template with sections for vulnerability details, lessons learned, and prevention steps.
* **Bug Fixes**
  * Improved test execution reliability by standardizing how test commands are launched across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->