### PR TITLE
🎨 Palette: Add primary variant to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,7 @@
+## 2024-05-24 - Initial File
+**Learning:** Initial Palette journal file created.
+**Action:** Ready for future entries.
+
+## 2024-05-24 - Primary Buttons
+**Learning:** Adding the `variant="primary"` attribute to main action buttons helps them stand out and improves visual hierarchy.
+**Action:** Always add `variant="primary"` to main action buttons in Gradio interfaces.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to the "Authenticate" and "Run" buttons in the Gradio interface.
🎯 Why: To improve visual hierarchy and draw attention to primary actions, enhancing usability.
📸 Before/After: See screenshots attached to the PR.
♿ Accessibility: Improves visual distinction of primary actions, benefiting users who rely on clear visual cues.

---
*PR created automatically by Jules for task [13858170843959587267](https://jules.google.com/task/13858170843959587267) started by @haseeb-heaven*