### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection vulnerability in subprocess call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-28 - Windows shell=True command injection
+**Vulnerability:** subprocess.run used shell=os.name == "nt" (which evaluates to True on Windows).
+**Learning:** Even when passing arguments as a list to subprocess on Windows, if shell=True is set, Windows processes shell metacharacters, leading to command injection if input is dynamic.
+**Prevention:** Always use shell=False by default (which is the Python default) and pass arguments as lists, even on Windows.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `subprocess.run` was called with `shell=os.name == "nt"` which evaluates to `True` on Windows. When combined with dynamic input (`marker_expr`), this exposes the application to command injection vulnerabilities, as Windows interprets shell metacharacters even when arguments are passed as a list.
🎯 Impact: An attacker who can control the `service` input could inject arbitrary shell commands that execute with the privileges of the running application on Windows environments.
🔧 Fix: Replaced `shell=os.name == "nt"` with `shell=False` in `framework/task_runner.py` to ensure arguments are passed directly to the executable without shell interpretation, neutralizing the injection risk.
✅ Verification: Ran the `pytest` test suite and verified the fix resolves the Bandit B602 warning.

---
*PR created automatically by Jules for task [46824071598236916](https://jules.google.com/task/46824071598236916) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test execution on Windows by avoiding shell-based process invocation, reducing the risk of command injection and making command handling more consistent across platforms.
- **Documentation**
  - Added a security note highlighting safer subprocess usage patterns and recommending non-shell execution with argument lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->