### PR TITLE
🎨 Palette: Add primary variants to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Visual Hierarchy in Gradio Forms
+**Learning:** Main action buttons like "Run" and "Authenticate" in Gradio often blend in with secondary actions (like "Clear" or "Generate New Auth URL"). This lacks clear visual hierarchy, potentially confusing users or leading to accidental clicks on the secondary action.
+**Action:** Always assign `variant='primary'` to main action buttons when they are placed near secondary buttons to establish clear visual hierarchy and guide the user's attention.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to the "Authenticate" and "Run" buttons in the Gradio interface.
🎯 Why: To establish clear visual hierarchy and distinguish primary actions from secondary actions (like "Clear" or "Generate New Auth URL").
📸 Before/After: Action buttons now appear with primary styling rather than default gray, drawing user attention to the next logical step.
♿ Accessibility: Improves visual distinction and user flow guidance, reducing cognitive load when interacting with forms.

---
*PR created automatically by Jules for task [8154535483280564178](https://jules.google.com/task/8154535483280564178) started by @haseeb-heaven*