### PR TITLE
🎨 Palette: Add primary variant to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,6 @@
+## 2026-06-29 - Initial check
+**Learning:** Checking for standard GUI apps accessibility opportunities in Gradio interfaces. Need to check Gradio inputs/outputs layout and states.
+**Action:** Inspect gws_assistant/gradio_app.py for potential layout/UX improvements.
+## 2026-06-29 - Gradio Button Visual Hierarchy
+**Learning:** Gradio UI action buttons next to secondary actions lacked clear visual distinction, making it harder for users to identify the primary path.
+**Action:** Added `variant="primary"` to main action buttons ("Run" and "Authenticate") when placed alongside secondary buttons ("Clear" and "Generate New Auth URL") to establish a clear visual hierarchy.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 **What**: Added `variant="primary"` to the main action buttons ("Run" and "Authenticate") in the Gradio UI.
🎯 **Why**: When primary action buttons are placed adjacent to secondary buttons (like "Clear" or "Generate New Auth URL") without visual distinction, users might accidentally click the wrong button or take longer to identify the primary path. Adding the primary variant establishes a clear visual hierarchy.
📸 **Before/After**: The main buttons are now highlighted with the primary theme color, drawing user attention appropriately, while secondary actions remain styled by default.
♿ **Accessibility**: Improves cognitive accessibility by clearly distinguishing primary calls-to-action from secondary ones, reducing errors for all users.

---
*PR created automatically by Jules for task [14158520427635659466](https://jules.google.com/task/14158520427635659466) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the visual hierarchy of key actions in the app by highlighting primary buttons.
  * The main “Run” and “Authenticate” actions now stand out more clearly next to secondary options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->