### PR TITLE
🎨 Palette: Add primary variants to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-30 - Add Primary Variants to Main Action Buttons
+**Learning:** When main action buttons like "Run" or "Authenticate" lack primary variant styling, they blend with secondary buttons, disrupting visual hierarchy and potentially leading to accidental misclicks.
+**Action:** Assign `variant="primary"` to primary actions in Gradio when placed near secondary actions to establish clear intent.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to main action buttons (`submit_auth_button` and `run_button`).
🎯 Why: Establishes visual hierarchy to prevent accidental clicks on secondary buttons (like "Clear" or "Regenerate Auth URL").
📸 Before/After: Documented in UI verification. Primary actions are now visually distinct.
♿ Accessibility: Improves clear action discoverability for cognitive and visual accessibility.

---
*PR created automatically by Jules for task [11487587546778658030](https://jules.google.com/task/11487587546778658030) started by @haseeb-heaven*