### PR TITLE
🛡️ Sentinel: [HIGH] Fix shell injection risk in task runner

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-30 - Fix shell injection risk on Windows in task runner
+**Vulnerability:** `subprocess.run` was called with `shell=os.name == "nt"`, evaluating to `shell=True` on Windows environments while passing a list of arguments.
+**Learning:** Using `shell=True` with an argument list on Windows can still trigger the command interpreter (`cmd.exe`) and expose the application to shell injection if variables (like `marker_expr`) contain metacharacters.
+**Prevention:** Explicitly use `shell=False` when executing commands with a list of arguments unless shell features (like pipes or redirects) are strictly required. Python handles execution natively on Windows without needing a shell interpreter.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,8 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # shell=False to prevent shell injection vulnerabilities on Windows
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `subprocess.run` was being called with `shell=os.name == "nt"`, which evaluates to `shell=True` on Windows. Passing a list of arguments to a subprocess call with `shell=True` triggers shell interpretation of metacharacters, opening a vector for shell injection vulnerabilities.
🎯 Impact: A malicious actor could potentially execute arbitrary shell commands if any part of the arguments list comes from unsanitized input and contains shell metacharacters.
🔧 Fix: Changed the subprocess call to explicitly use `shell=False` (which is secure and the recommended approach when passing a list of arguments).
✅ Verification: Ran `pytest` test suite to ensure tests still pass, and verified with `bandit` that the security issue is resolved.

---
*PR created automatically by Jules for task [13732805352188868805](https://jules.google.com/task/13732805352188868805) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task execution on Windows by avoiding a shell-based command path, reducing the risk of unexpected command interpretation.
  * Strengthened security when running test-related tasks with list-style commands, while keeping existing behavior and settings intact.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->