### PR TITLE
🛡️ Sentinel: [HIGH] Fix shell injection vulnerability in subprocess call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Subprocess Shell Injection on Windows]
+**Vulnerability:** Found `subprocess.run` called with `shell=os.name == "nt"` and a list of arguments in `framework/task_runner.py`.
+**Learning:** On Windows, using `shell=True` with a list of arguments causes `subprocess` to join them into a string and execute via `cmd.exe /c`. This exposes the application to shell injection if any arguments contain shell metacharacters (like `&` or `|`), negating the security benefit of passing arguments as a list.
+**Prevention:** Always use `shell=False` (the default) when passing arguments as a list to `subprocess.run()`, even on Windows, unless explicitly executing a built-in shell command or `.bat` file.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
- 🚨 Severity: HIGH
- 💡 Vulnerability: `subprocess.run` called with `shell=True` on Windows using a list of arguments, which can lead to shell injection or unintended meta-character execution.
- 🎯 Impact: High, could allow arbitrary command execution if the command arguments were manipulated.
- 🔧 Fix: Replaced `shell=os.name == "nt"` with `shell=False` (enforces default secure behavior).
- ✅ Verification: The script and test suite executes successfully and `bandit` no longer flags the file.

---
*PR created automatically by Jules for task [10768499794638773314](https://jules.google.com/task/10768499794638773314) started by @haseeb-heaven*