### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection vulnerability in subprocess call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-02 - [shell=True on Windows]
+**Vulnerability:** Found `subprocess.run` with `shell=os.name == "nt"` and an argument list in `framework/task_runner.py`.
+**Learning:** Using `shell=True` on Windows with list arguments doesn't escape safely, creating a command injection vulnerability. Since `sys.executable` (a direct binary) is used as the command, `shell=False` is strictly correct and safer across platforms.
+**Prevention:** Avoid `shell=True` unless explicitly calling built-in shell commands (like `dir`), and even then, heavily sanitize all interpolated inputs. Always default to `shell=False` for executing python scripts or standard binaries.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,8 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # Fix shell injection vulnerability on Windows (shell=True with list argument is dangerous)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Used `shell=os.name == "nt"` in `subprocess.run` inside `framework/task_runner.py`. On Windows, using `shell=True` with a list argument allows unintended shell interpretation of arguments and potential shell injection.
🎯 **Impact:** If `marker_expr` or environment variables were derived from untrusted input, it could allow arbitrary command execution on the host system.
🔧 **Fix:** Explicitly set `shell=False` (default behavior). The command `cmd` is already provided as an argument list with `sys.executable` at the beginning, so a shell isn't needed. `shell=False` provides safe, cross-platform execution.
✅ **Verification:** Verified by running bandit to confirm the vulnerability is resolved and manually executing `task_runner.py` directly to ensure regressions are absent.

---
*PR created automatically by Jules for task [7932801029592955837](https://jules.google.com/task/7932801029592955837) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test command execution to avoid a Windows-specific command injection risk.
  * Kept the same timeout and output handling while making process execution safer.
* **Documentation**
  * Added a security note outlining the issue and recommending safer default command execution settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->