### PR TITLE
🎨 Palette: Add primary variants to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-24 - Primary action variants in Gradio
+**Learning:** Gradio UI doesn't visually distinguish primary and secondary buttons by default, which can lead to accidental clicks on destructive or secondary actions like "Clear" when they are next to main actions like "Run".
+**Action:** Always assign `variant='primary'` to main action buttons when they are placed near secondary buttons to establish clear visual hierarchy.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to the "Authenticate" and "Run" buttons in the Gradio interface.
🎯 Why: To establish clear visual hierarchy and prevent accidental clicks on secondary actions like "Clear" or "Generate New Auth URL" when they are placed next to the main action buttons.
📸 Before/After: Before, all buttons had the default secondary styling. After, the main action buttons stand out with primary styling.
♿ Accessibility: Improved visual cues for users navigating the UI, making the primary path clearer, especially for users with cognitive or visual impairments.

---
*PR created automatically by Jules for task [12564991033067518497](https://jules.google.com/task/12564991033067518497) started by @haseeb-heaven*