### PR TITLE
🎨 Palette: Add primary variant to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-03 - Primary Button Visual Hierarchy
+**Learning:** Gradio main action buttons (like "Run" or "Authenticate") lack visual prominence when placed next to secondary actions (like "Clear"), which can lead to accidental clicks or confusion.
+**Action:** Always assign `variant='primary'` to main action buttons in Gradio interfaces when placed near secondary buttons to establish a clear visual hierarchy.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant='primary'` to the "Run" and "Authenticate" buttons in the Gradio UI and logged the insight in `.jules/palette.md`.
🎯 Why: To establish a clear visual hierarchy between primary actions and secondary actions (like "Clear"), preventing accidental clicks.
📸 Before/After: Visual contrast between action buttons is significantly enhanced.
♿ Accessibility: Improves visual accessibility and cognitive load by clearly highlighting the primary path forward.

---
*PR created automatically by Jules for task [17150150658593496805](https://jules.google.com/task/17150150658593496805) started by @haseeb-heaven*