### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal vulnerability on Windows paths

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+# Sentinel Journal
+## 2025-02-27 - Fix path traversal vulnerability on Windows paths
+**Vulnerability:** Path traversal detection logic (`_is_safe_file_path`) used `os.path.isabs()` to check for absolute paths, which fails to correctly identify Windows-style absolute paths (e.g., `C:\Windows\...`) when the application runs in a Linux/Posix environment.
+**Learning:** Functions like `os.path.isabs()` and `os.path.normpath()` use the host OS conventions (i.e., `posixpath` on Linux, `ntpath` on Windows). When validating untrusted input that might originate from or mimic a different operating system, relying solely on `os.path` functions can lead to bypasses.
+**Prevention:** Always use cross-platform parsing methods, such as checking both `pathlib.PureWindowsPath` and `pathlib.PurePosixPath`, when validating the structure of paths from untrusted sources, to ensure correct detection regardless of the host operating system.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,8 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # Use shell=False to prevent shell injection, cmd is a list
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")

--- a/gws_assistant/execution/helpers.py
+++ b/gws_assistant/execution/helpers.py
@@ -2,6 +2,7 @@ import ast
 import json
 import logging
 import os
+import pathlib
 import re
 from datetime import datetime
 from typing import Any
@@ -52,8 +53,13 @@ def _is_safe_file_path(file_path: str) -> bool:
     if '..' in normalized:
         return False
 
-    # Check for absolute paths - only allow if within sandbox directories
-    if os.path.isabs(normalized):
+    # Check for absolute paths (cross-platform) - only allow if within sandbox directories
+    is_absolute = (
+        os.path.isabs(normalized) or
+        pathlib.PureWindowsPath(normalized).is_absolute() or
+        pathlib.PurePosixPath(normalized).is_absolute()
+    )
+    if is_absolute:
         # Get sandbox directories from environment or use defaults
         sandbox_dirs = [
             os.environ.get('GWS_SANDBOX_DIR', ''),


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `_is_safe_file_path` used `os.path.isabs()` to check for absolute paths, which fails to identify Windows-style absolute paths (e.g., `C:\Windows\...`) when running on Linux. Also fixed a HIGH severity `subprocess.run` shell injection in `framework/task_runner.py` where `shell=os.name == "nt"` was dynamically used with a list of arguments.
🎯 Impact: An attacker could bypass the absolute path check and access files outside the sandbox if cross-platform path validation is expected, or potentially inject shell commands on Windows executions.
🔧 Fix: Used `pathlib.PureWindowsPath` and `pathlib.PurePosixPath` to accurately detect absolute paths across platforms, ensuring Windows absolute paths are correctly identified and blocked. Changed `subprocess.run` to always use `shell=False`.
✅ Verification: Ran `pytest` to ensure the `test_is_safe_file_path_blocks_path_traversal` test now passes, and `bandit` no longer flags the `subprocess` call.

---
*PR created automatically by Jules for task [18435904327256798056](https://jules.google.com/task/18435904327256798056) started by @haseeb-heaven*