### PR TITLE
🎨 Palette: [UX improvement] Add primary variant to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Establish visual hierarchy in Gradio forms
+**Learning:** Gradio default buttons all look the same, making primary actions (like "Run" or "Authenticate") blend in with secondary actions (like "Clear"). This can lead to accidental clicks.
+**Action:** Always assign `variant='primary'` to main action buttons when placed next to secondary buttons.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to the "Run" and "Authenticate" buttons in the Gradio UI.
🎯 Why: To establish a clear visual hierarchy between primary actions and secondary actions (like "Clear"), preventing accidental clicks and improving overall usability.
📸 Before/After: Buttons now have distinctive primary styling instead of blending in with secondary buttons.
♿ Accessibility: Enhances visual cues for primary calls to action, aiding users with cognitive or visual processing needs.

---
*PR created automatically by Jules for task [7328749615883318780](https://jules.google.com/task/7328749615883318780) started by @haseeb-heaven*