### PR TITLE
🎨 Palette: Add primary variants to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Establish Clear Visual Hierarchy in Gradio
+**Learning:** Gradio interfaces can suffer from poor visual hierarchy when primary and secondary actions (like "Run" and "Clear", or "Authenticate" and "Generate New Auth URL") are placed next to each other with the same default visual weight, leading to accidental clicks.
+**Action:** Always assign `variant='primary'` to main action buttons to establish clear visual hierarchy and guide the user's focus appropriately.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 **What:** Added `variant="primary"` to the "Run" and "Authenticate" buttons in the Gradio UI.
🎯 **Why:** To establish a clear visual hierarchy between primary actions and secondary actions (like "Clear" or "Generate New Auth URL"), preventing accidental clicks and guiding user focus.
📸 **Before/After:** Verified locally via Playwright screenshots. The primary actions are now styled correctly and prominently.
♿ **Accessibility:** Improves cognitive accessibility by clearly distinguishing the primary path of action for users navigating the interface.

---
*PR created automatically by Jules for task [3180554652055974283](https://jules.google.com/task/3180554652055974283) started by @haseeb-heaven*