### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection risk in task runner

### DIFF
--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,8 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # Security: shell=False prevents command injection when executing lists
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: A `subprocess.run()` call was found executing with `shell=os.name == "nt"`. When `shell=True`, it is possible for an attacker to inject arbitrary shell commands if the inputs to the command list are maliciously crafted.
🎯 Impact: An attacker could potentially achieve arbitrary command execution on the host machine running the tests, leading to full system compromise or data exfiltration.
🔧 Fix: Hardcoded `shell=False` for all operating systems, as `cmd` is already constructed as a list, mitigating command injection vulnerabilities while preserving functionality. Added a security comment.
✅ Verification: Ran `bandit -r framework/task_runner.py` and verified B602 is no longer reported. Ran relevant test suite to ensure functionality remains intact.

---
*PR created automatically by Jules for task [14473410987472238659](https://jules.google.com/task/14473410987472238659) started by @haseeb-heaven*