### PR TITLE
🎨 Palette: Add primary variants to main action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-06 - Establish visual hierarchy for primary actions
+**Learning:** In form interfaces with multiple side-by-side actions (like Run/Clear or Authenticate/Regenerate), users can accidentally trigger destructive or secondary actions if all buttons carry the same visual weight. Gradio defaults to uniform button styling which exacerbates this.
+**Action:** Always assign `variant='primary'` to main action buttons (e.g., 'Run', 'Authenticate') when placed adjacent to secondary/destructive buttons to establish clear visual hierarchy and prevent accidental clicks.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", visible=False, variant="primary")
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to the 'Run' and 'Authenticate' buttons in the Gradio interface.
🎯 Why: To establish clear visual hierarchy for primary actions and prevent accidental clicks on secondary or destructive buttons (like 'Clear').
📸 Before/After: Primary actions now stand out visually with a distinct background color.
♿ Accessibility: Better visual contrast and cognitive clarity for the primary user path.

---
*PR created automatically by Jules for task [5044689875732332583](https://jules.google.com/task/5044689875732332583) started by @haseeb-heaven*