### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection risk in task_runner

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-08 - [subprocess shell=True vulnerability on Windows]
+**Vulnerability:** Found `shell=os.name == "nt"` in `subprocess.run` inside `framework/task_runner.py`, effectively resolving to `shell=True` on Windows.
+**Learning:** Developers sometimes use `shell=True` on Windows to resolve pathing or executable extensions seamlessly, but it unnecessarily increases the risk of command injection.
+**Prevention:** Always use `shell=False` for cross-platform compatibility and ensure paths are passed correctly in the command list, even on Windows.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `subprocess.run` was called with `shell=os.name == "nt"`, making it evaluate to `shell=True` on Windows environments, flagged by Bandit B602.
🎯 Impact: While the current `cmd` argument is built safely, `shell=True` introduces an unnecessary risk of command injection if the command arguments are ever modified to include untrusted user input in the future.
🔧 Fix: Changed `shell=os.name == "nt"` to `shell=False` to securely launch the subprocess across all platforms.
✅ Verification: Run `bandit -r .` to confirm issue B602 is resolved. Run `pytest` to confirm tests continue to execute correctly without shell functionality.

---
*PR created automatically by Jules for task [10567590894118700695](https://jules.google.com/task/10567590894118700695) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subprocess execution safety during testing by ensuring consistent use of secure command parameters across all platforms. This change eliminates a potential vulnerability affecting command execution on Windows systems, enhancing overall application security and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->