### PR TITLE
🎨 Palette: Improve visual hierarchy of primary buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-11 - Visual Hierarchy in Gradio Forms
+**Learning:** Gradio's default buttons lack clear visual hierarchy, which can lead to accidental clicks on secondary actions (like "Clear" instead of "Run").
+**Action:** Always assign `variant='primary'` to main action buttons placed near secondary buttons to establish clear visual hierarchy.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to the "Authenticate" and "Run" buttons in the Gradio UI.
🎯 Why: To establish clear visual hierarchy and prevent accidental clicks on secondary buttons like "Clear" or "Generate New Auth URL".
📸 Before/After: The primary buttons now stand out visually from secondary actions.
♿ Accessibility: Clearer visual cues for main actions benefit all users, especially those navigating by keyboard or with visual impairments.

---
*PR created automatically by Jules for task [12348802448797145529](https://jules.google.com/task/12348802448797145529) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Gradio interface so the primary “Authenticate” and “Run” actions are visually emphasized.
  * Improved visual hierarchy between primary and secondary buttons to help reduce accidental clicks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->