### PR TITLE
🛡️ Sentinel: [HIGH] Prevent secret token leakage in Telegram error handling

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Secret Leakage via HTTP Exceptions]
+**Vulnerability:** The application caught HTTP exceptions during Telegram API calls and logged the raw exception objects. Standard HTTP exceptions (like `urllib.error.HTTPError` or `requests.exceptions.HTTPError`) often include the full request URL in their string representation. Because the Telegram API requires embedding the secret bot token directly in the URL path (`/bot<token>/`), logging the error leaked the secret token.
+**Learning:** Failing securely means ensuring error logs and stack traces never expose sensitive data. APIs that use path-based or query-parameter-based authentication are especially vulnerable to this type of leakage during error handling.
+**Prevention:** Always pass exception messages through a redaction function (e.g., `redact_sensitive(e)`) or manually strip URLs before logging them when interacting with APIs that embed secrets in the URL.

--- a/gws_assistant/tools/telegram.py
+++ b/gws_assistant/tools/telegram.py
@@ -83,10 +83,10 @@ def send_telegram(message, context=None):
         print("Telegram message sent.")
         return True
     except urllib.error.URLError as e:
-        print(f"Error sending Telegram message: {e}")
+        print(f"Error sending Telegram message: {redact_sensitive(e)}")
         return False
     except Exception as e:
-        print(f"Exception sending Telegram message: {e}")
+        print(f"Exception sending Telegram message: {redact_sensitive(e)}")
         return False
 
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: When the Telegram API returns an HTTP error, the `urllib.error.HTTPError` object is directly printed to the console. Because the Telegram API design embeds the bot token directly in the URL path (`/bot<token>/`), the exception's string representation leaks the raw `TELEGRAM_BOT_TOKEN` in the error message.
🎯 Impact: If these logs are persisted, collected by a monitoring system, or visible in an CI/CD pipeline, an attacker could extract the Telegram Bot Token, leading to unauthorized access to the bot account.
🔧 Fix: Passed the exception string through the existing `redact_sensitive()` function before printing it to ensure the token is masked as `[REDACTED]`.
✅ Verification: Verified locally by triggering an HTTP error with a mock token and confirming the URL in the output was successfully redacted.

---
*PR created automatically by Jules for task [12353704016765026902](https://jules.google.com/task/12353704016765026902) started by @haseeb-heaven*