### PR TITLE
⚡ Bolt: Optimize singular_suffixes check in resolver

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Python String Prefix/Suffix Optimization
+**Learning:** Checking for multiple prefixes/suffixes using a list and `any(s.endswith(x) for x in list)` adds Python-level iteration overhead. Passing a static tuple directly to `str.startswith()` or `str.endswith()` leverages C-level implementation, making it significantly faster.
+**Action:** Always use static tuples with `startswith`/`endswith` for multiple substring matching instead of generator expressions or chained `or` conditions, provided the tuple is a static literal.

--- a/gws_assistant/execution/resolver.py
+++ b/gws_assistant/execution/resolver.py
@@ -575,7 +575,8 @@ class ResolverMixin:
 
                 # 2. If we resolved to a list, but we are a single-token placeholder
                 # (e.g. {{task-1.id}}), pick the first item.
-                singular_suffixes = [
+                # Optimization: using a static tuple with endswith is implemented in C and evaluates faster
+                singular_suffixes = (
                     ".id",
                     ".name",
                     ".url",
@@ -587,8 +588,8 @@ class ResolverMixin:
                     ".documentId",
                     ".fileId",
                     ".file_id",
-                ]
-                if isinstance(resolved, list) and resolved and any(path.endswith(s) for s in singular_suffixes):
+                )
+                if isinstance(resolved, list) and resolved and path.endswith(singular_suffixes):
                     self.logger.debug(f"DEBUG: Smart-unwrapping list result for '{path}' to first item.")
                     # We have a list. Check if we need to do the folder heuristic.
                     # Since resolved is likely just strings here (e.g. ['folder_id', 'doc_id']),


### PR DESCRIPTION
💡 What: Converted `singular_suffixes` from a list to a static tuple and replaced the generator expression `any(path.endswith(s) for s in singular_suffixes)` with `path.endswith(singular_suffixes)`.
🎯 Why: Python's `str.endswith()` and `str.startswith()` methods accept tuples directly and evaluate the matches natively in C. This removes the overhead of Python-level generator expressions and iteration.
📊 Impact: Expected to reduce execution time in `_resolve_tokens` when checking for singular suffixes, especially for high-frequency token resolution.
🔬 Measurement: Verify by running tests. Profile execution time of `path.endswith(tuple)` vs `any()` in a tight loop to see the speedup.

---
*PR created automatically by Jules for task [4193472164486395285](https://jules.google.com/task/4193472164486395285) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved processing speed when resolving certain placeholder paths by optimizing suffix matching.
  * Preserved existing behavior for automatically selecting the first item from list results for supported path types.

* **Documentation**
  * Added guidance on using efficient prefix and suffix checks in Python.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->