### PR TITLE
🛡️ Sentinel: [HIGH] Fix secret leakage in exception logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-24 - Prevent Secret Leakage in Exception Messages
+**Vulnerability:** Telegram API token could be leaked in stdout when a `urllib.error.URLError` or general `Exception` is caught and printed without redaction.
+**Learning:** URLs embedded within exception objects (like HTTPError) can expose credentials when cast to strings.
+**Prevention:** Always wrap exception objects with `redact_sensitive()` before printing or logging them.

--- a/gws_assistant/tools/telegram.py
+++ b/gws_assistant/tools/telegram.py
@@ -83,10 +83,10 @@ def send_telegram(message, context=None):
         print("Telegram message sent.")
         return True
     except urllib.error.URLError as e:
-        print(f"Error sending Telegram message: {e}")
+        print(f"Error sending Telegram message: {redact_sensitive(e)}")
         return False
     except Exception as e:
-        print(f"Exception sending Telegram message: {e}")
+        print(f"Exception sending Telegram message: {redact_sensitive(e)}")
         return False
 
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: When `urllib.error.URLError` or a general `Exception` occurs, the exception object might contain the request URL, which embeds the secret Telegram bot token. Printing this exception directly without redaction leaks the token into logs or standard output.
🎯 Impact: An attacker or unauthorized user with access to application logs could extract the Telegram API token and hijack the bot.
🔧 Fix: Wrapped the exception objects with `redact_sensitive(e)` before printing them in `gws_assistant/tools/telegram.py`.
✅ Verification: Tests passing successfully and exception messages are confirmed to be routed through `redact_sensitive()`.

---
*PR created automatically by Jules for task [16316702865762283424](https://jules.google.com/task/16316702865762283424) started by @haseeb-heaven*