### PR TITLE
🎨 Palette: UX Improvements to Auth and Run Forms

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-12 - Primary buttons and input submission
+**Learning:** In Gradio applications with multiple inputs and buttons, users often paste long strings (like auth codes) which can cause the layout to jump and stretch awkwardly. Also, it's critical to make the primary call-to-action (Authenticate, Run) visually distinct from secondary buttons (Generate New Auth URL, Clear) to guide the user's focus, and also make inputs submittable using the 'Enter' key.
+**Action:** Added `max_lines=1` to the authorization code input to prevent layout stretching upon pasting. Added `variant="primary"` to the "Authenticate" and "Run" buttons to emphasize them. Bound the `submit` event to the `auth_code_input` to allow keyboard submission.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
-                    visible=False
+                    visible=False,
+                    max_lines=1
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", visible=False, variant="primary")
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -301,9 +302,10 @@ def create_interface() -> gr.Blocks:
                 label="Request",
                 lines=4,
                 placeholder="Example: List recent Gmail messages and show details",
+                autofocus=True
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)
@@ -387,6 +389,18 @@ def create_interface() -> gr.Blocks:
         )
 
         submit_auth_button.click(
+            fn=on_auth_submit,
+            inputs=[client_config_state, auth_code_input],
+            outputs=[
+                credentials_file_state,
+                auth_status,
+                auth_code_input,
+                regenerate_url_button,
+                auth_message
+            ]
+        )
+
+        auth_code_input.submit(
             fn=on_auth_submit,
             inputs=[client_config_state, auth_code_input],
             outputs=[


### PR DESCRIPTION
💡 What:
- Added `variant='primary'` to the 'Authenticate' and 'Run' buttons.
- Bound the 'Enter' key submit event on the authorization code input textbox.
- Added `max_lines=1` to the authorization code input.
- Added `autofocus=True` to the request input box.

🎯 Why:
- The primary call-to-action buttons should be visually distinct to guide user focus.
- Users expect to be able to submit forms by pressing Enter in the input field.
- Pasting a long authorization code caused the text box to expand and shift the UI layout. Constraining it to 1 line prevents this jank.
- Users expect the request input to be focused by default so they can start typing right away.

📸 Before/After:
Before: The "Authenticate" and "Run" buttons were plain gray. The auth code input would expand when a long code was pasted. The auth code input could not be submitted via "Enter".
After: The "Authenticate" and "Run" buttons are a distinct orange color. The auth input is constrained to 1 line. The auth code input can be submitted via "Enter".

♿ Accessibility:
- Improved keyboard navigation by allowing form submission via the Enter key on the authorization input field.

---
*PR created automatically by Jules for task [2569827028371028540](https://jules.google.com/task/2569827028371028540) started by @haseeb-heaven*