### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-15 - Fast Multiple Prefix/Suffix Checking
+**Learning:** Using generator expressions like `any(s.startswith(p) for p in prefixes)` or chained `or` conditions for prefix/suffix checking introduces significant overhead. Passing a static tuple directly to `str.startswith()` or `str.endswith()` is implemented in C and executes much faster.
+**Action:** Always use tuples with `startswith()` and `endswith()` when checking multiple static prefixes or suffixes.

--- a/gws_assistant/execution/resolver.py
+++ b/gws_assistant/execution/resolver.py
@@ -575,7 +575,8 @@ class ResolverMixin:
 
                 # 2. If we resolved to a list, but we are a single-token placeholder
                 # (e.g. {{task-1.id}}), pick the first item.
-                singular_suffixes = [
+                # Performance optimization: endswith with a tuple is implemented in C and evaluates faster
+                singular_suffixes = (
                     ".id",
                     ".name",
                     ".url",
@@ -587,8 +588,8 @@ class ResolverMixin:
                     ".documentId",
                     ".fileId",
                     ".file_id",
-                ]
-                if isinstance(resolved, list) and resolved and any(path.endswith(s) for s in singular_suffixes):
+                )
+                if isinstance(resolved, list) and resolved and path.endswith(singular_suffixes):
                     self.logger.debug(f"DEBUG: Smart-unwrapping list result for '{path}' to first item.")
                     # We have a list. Check if we need to do the folder heuristic.
                     # Since resolved is likely just strings here (e.g. ['folder_id', 'doc_id']),

--- a/gws_assistant/verification_engine.py
+++ b/gws_assistant/verification_engine.py
@@ -1676,7 +1676,8 @@ class VerificationEngine:
     def _is_valid_drive_id(cls, value: str) -> bool:
         val_str = str(value)
         # Allow internal placeholders and specific recognized prefixes
-        if any(val_str.startswith(prefix) for prefix in ["sheet-", "doc-", "folder-", "file-", "evt-", "sent-", "$", "{{"]):
+        # Performance optimization: startswith with a tuple is implemented in C and evaluates faster
+        if val_str.startswith(("sheet-", "doc-", "folder-", "file-", "evt-", "sent-", "$", "{{")):
             return len(val_str) > 2
         # Regular Drive IDs are URL-safe base64 encoded (25-60 chars).
         # Allow: alphanumeric, hyphen, underscore, period, and equals padding.


### PR DESCRIPTION
💡 What: Replaced generator expressions `any(path.endswith(s))` and `any(val.startswith(p))` with `path.endswith(tuple)` and `val.startswith(tuple)`.
🎯 Why: When checking for multiple string prefixes or suffixes, passing a static tuple directly to these methods executes at the C level, avoiding the overhead of Python generator expressions and function calls on every item.
📊 Impact: Reduces overhead in hot paths involving path and ID validation, improving execution speed of validation checks.
🔬 Measurement: Can be verified using micro-benchmarks comparing `any(s.startswith(x) for x in list)` vs `s.startswith(tuple)`. Ensure tests still pass using standard test suites.

---
*PR created automatically by Jules for task [10364498917904578421](https://jules.google.com/task/10364498917904578421) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved internal validation and placeholder processing for faster handling of common path and identifier checks.
  * Preserved existing behavior while reducing overhead when matching multiple prefixes or suffixes.

* **Documentation**
  * Added guidance recommending tuple-based prefix and suffix matching for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->