### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection vulnerability in subprocess call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2026-07-15 - [CRITICAL] Prevent Command Injection in Task Runner
+
+**Vulnerability:** Found `subprocess.run(..., shell=os.name == "nt")` in `framework/task_runner.py` which sets `shell=True` on Windows environments, creating a potential command injection vector.
+**Learning:** Evaluated boolean statements (like `os.name == "nt"`) are sometimes incorrectly used by developers to conditionally apply `shell=True` on Windows. However, when executing a direct binary using an argument list (like `sys.executable`), Windows does not strictly require `shell=True`.
+**Prevention:** Always use `shell=False` across all platforms when passing a list of arguments to `subprocess.run`, especially when the first argument is a direct path to an executable like `sys.executable`.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,8 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # Security: shell=False prevents command injection vulnerabilities; sys.executable does not require a shell
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Command injection risk due to `shell=True` (evaluated on Windows via `os.name == "nt"`) in `subprocess.run`.
🎯 Impact: If untrusted input reaches the command arguments, it could allow arbitrary command execution on the host system.
🔧 Fix: Explicitly set `shell=False` across all platforms. Calling `sys.executable` does not require a shell.
✅ Verification: Ran `bandit` security scanner and verified no `B602` issues remain. Tests pass successfully.

---
*PR created automatically by Jules for task [6538879972180520399](https://jules.google.com/task/6538879972180520399) started by @haseeb-heaven*