### PR TITLE
🎨 Palette: Gradio UX Component Polish

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Gradio Component Polish
+**Learning:** Gradio interfaces can feel unpolished without explicit primary action styling (`variant="primary"`) and keyboard support (Enter-to-submit on inputs). Textboxes intended for tokens or codes can awkwardly stretch the layout if `max_lines=1` is not set.
+**Action:** Always apply `variant="primary"` to primary actions, add `.submit()` bindings to input textboxes, and enforce `max_lines=1` for single-line tokens.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
+                    max_lines=1,
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +304,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)
@@ -387,6 +388,18 @@ def create_interface() -> gr.Blocks:
         )
 
         submit_auth_button.click(
+            fn=on_auth_submit,
+            inputs=[client_config_state, auth_code_input],
+            outputs=[
+                credentials_file_state,
+                auth_status,
+                auth_code_input,
+                regenerate_url_button,
+                auth_message
+            ]
+        )
+
+        auth_code_input.submit(
             fn=on_auth_submit,
             inputs=[client_config_state, auth_code_input],
             outputs=[


### PR DESCRIPTION
💡 What: Added `variant="primary"` to main action buttons ("Run" and "Authenticate") for better visual hierarchy. Restricted `auth_code_input` to single-line with `max_lines=1` and enabled Enter-to-submit by binding `.submit()` on the `auth_code_input`.
🎯 Why: Secondary buttons and primary buttons were indistinguishable, making the application less intuitive. Enter key support on the auth code input provides keyboard accessibility. Uncapped text input for a single short token stretches UI ungracefully.
📸 Before/After: Before, buttons shared default styling, and pasting auth tokens created unnecessarily tall inputs. After, primary buttons pop with color, the token input is neat, and users can submit auth keys natively with keyboard.
♿ Accessibility: Improved visual contrast and added keyboard submission support, eliminating the strict requirement to navigate to a button using mouse.

---
*PR created automatically by Jules for task [16833138878685699992](https://jules.google.com/task/16833138878685699992) started by @haseeb-heaven*