### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command Injection Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-20 - [HIGH] Fix Command Injection Vulnerability in Subprocess
+**Vulnerability:** `subprocess.run` was called with `shell=os.name == "nt"` in `framework/task_runner.py`.
+**Learning:** Hardcoding `shell=True` on Windows environments for running subprocesses with array arguments creates a severe command injection vulnerability if any of the arguments are user-controlled. The assumption that Windows requires `shell=True` to execute basic python modules using `sys.executable` is incorrect.
+**Prevention:** Always explicitly pass `shell=False` to subprocess module calls across all platforms, especially when passing the command as a list array. Do not rely on OS checks to conditionally enable shell execution unless strictly required and thoroughly sanitized.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,8 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # Security: Explicitly pass shell=False across all platforms to prevent Command Injection.
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `subprocess.run` was called with `shell=os.name == "nt"`, allowing potential command injection on Windows environments when executing Python modules.
🎯 Impact: An attacker who can control arguments to `subprocess.run` could execute arbitrary shell commands on Windows.
🔧 Fix: Explicitly set `shell=False` across all platforms. Windows does not strictly require `shell=True` to execute binaries like `sys.executable`.
✅ Verification: Tested using `bandit` to ensure the B602 alert is resolved, and verified existing test cases pass to ensure no functional regressions.

---
*PR created automatically by Jules for task [5333345556262324427](https://jules.google.com/task/5333345556262324427) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened test execution security by preventing command injection across platforms.
  * Preserved existing timeout, retry, return-code, and error-handling behavior.
* **Documentation**
  * Added security guidance for safely invoking subprocesses with argument lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->