### PR TITLE
🛡️ Sentinel: [HIGH] Fix URL token leakage in Telegram tool exceptions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-17 - [URL Exception Token Leakage]
+**Vulnerability:** Telegram API bot token leaked in urllib.error.URLError string representation.
+**Learning:** Exception objects containing HTTP/URL errors can embed sensitive tokens within the URL string they hold.
+**Prevention:** Always wrap HTTP/URL exception objects with `redact_sensitive()` before printing or logging.

--- a/gws_assistant/tools/telegram.py
+++ b/gws_assistant/tools/telegram.py
@@ -83,10 +83,10 @@ def send_telegram(message, context=None):
         print("Telegram message sent.")
         return True
     except urllib.error.URLError as e:
-        print(f"Error sending Telegram message: {e}")
+        print(f"Error sending Telegram message: {redact_sensitive(e)}")
         return False
     except Exception as e:
-        print(f"Exception sending Telegram message: {e}")
+        print(f"Exception sending Telegram message: {redact_sensitive(e)}")
         return False
 
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The exception handling blocks in the Telegram tool (`gws_assistant/tools/telegram.py`) printed raw exception objects (like `urllib.error.URLError`), which contain the requested URL string, inherently leaking the Telegram API bot token.
🎯 Impact: If these logs or standard outputs are aggregated or exposed, an attacker could extract the sensitive bot token and gain unauthorized access to the Telegram bot.
🔧 Fix: Wrapped the exception variables in `redact_sensitive()` before printing to mask the embedded secrets.
✅ Verification: Tests run successfully, and manual inspection confirms the changes.

---
*PR created automatically by Jules for task [10378662130537826159](https://jules.google.com/task/10378662130537826159) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented sensitive Telegram API tokens from appearing in error messages and logs when network or unexpected errors occur.
  * Improved protection of sensitive information in URL-related exception output.

* **Documentation**
  * Added guidance for safely handling and redacting sensitive data in HTTP and URL exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->