### PR TITLE
🎨 Palette: Improve Gradio components UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Gradio Button Actions & Input UX
+**Learning:** In Gradio applications, primary actions (like "Run" or "Authenticate") blend in with secondary actions by default, which can cause confusion. Furthermore, textboxes used for long tokens like auth codes can stretch the layout awkwardly if `max_lines=1` is not set, and lack Enter-key submission by default, requiring keyboard users to tab out.
+**Action:** Always add `variant="primary"` to primary action buttons, set `max_lines=1` for single-line token inputs to prevent UI jumps, and bind the `.submit()` method on textboxes so users can submit by pressing Enter without breaking their flow.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
-                    visible=False
+                    visible=False,
+                    max_lines=1
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +304,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)
@@ -387,6 +388,18 @@ def create_interface() -> gr.Blocks:
         )
 
         submit_auth_button.click(
+            fn=on_auth_submit,
+            inputs=[client_config_state, auth_code_input],
+            outputs=[
+                credentials_file_state,
+                auth_status,
+                auth_code_input,
+                regenerate_url_button,
+                auth_message
+            ]
+        )
+
+        auth_code_input.submit(
             fn=on_auth_submit,
             inputs=[client_config_state, auth_code_input],
             outputs=[


### PR DESCRIPTION
💡 What: Added `variant="primary"` to main buttons, set `max_lines=1` for the auth code textbox, and enabled Enter-key submission on the auth code input.
🎯 Why: Makes the UI more intuitive by clearly highlighting primary actions and preventing layout jumps, while significantly improving keyboard navigation flow.
📸 Before/After: Verified locally via Playwright screenshots.
♿ Accessibility: Allows keyboard-only users to submit authorization codes by pressing Enter without having to tab to the submit button.

---
*PR created automatically by Jules for task [4522193469835942561](https://jules.google.com/task/4522193469835942561) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can submit an authorization code by pressing Enter in the input field.
  * The authorization code field now stays on a single line for a cleaner layout.

* **UI Improvements**
  * The primary Run action is more visually prominent.
  * The Authenticate button remains hidden until it is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->