### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: Potential for command injection on Windows via `shell=True` in `subprocess.run()`. Even though the inputs are hardcoded strings, `shell=True` is generally insecure and flagged by tools like Bandit.
🎯 Impact: Minimal since arguments are controlled, but standardizes secure subprocess calls across OS platforms.
🔧 Fix: Explicitly set `shell=False` on all platforms, including Windows, for `subprocess.run` in `framework/task_runner.py`.
✅ Verification: Verified using `pytest tests/test_smoke.py` and confirmed `bandit` no longer raises B602 on this line.

---
*PR created automatically by Jules for task [16548976538585004008](https://jules.google.com/task/16548976538585004008) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test execution reliability and security by consistently running test commands without an intermediate shell.
  * Preserved existing timeout handling and result reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->