### PR TITLE
🎨 Palette: Improve button visual hierarchy and auth form UX

### DIFF
--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
-                    visible=False
+                    visible=False,
+                    max_lines=1
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", visible=False, variant="primary")
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +304,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)
@@ -376,6 +377,18 @@ def create_interface() -> gr.Blocks:
                 submit_auth_button,
                 regenerate_url_button,
                 auth_message,
+                auth_message
+            ]
+        )
+
+        auth_code_input.submit(
+            fn=on_auth_submit,
+            inputs=[client_config_state, auth_code_input],
+            outputs=[
+                credentials_file_state,
+                auth_status,
+                auth_code_input,
+                regenerate_url_button,
                 auth_message
             ]
         )


### PR DESCRIPTION
**💡 What:**
- Added `variant="primary"` to the 'Authenticate' and 'Run' buttons.
- Constrained the auth code input to a single line using `max_lines=1`.
- Bound the `.submit()` event to the auth code input to allow Enter-key submission.

**🎯 Why:**
- Users often struggle to identify the primary call-to-action on complex forms. Highlighting the primary buttons improves visual hierarchy.
- Pasting long auth codes into multi-line textboxes causes the UI to awkwardly stretch vertically.
- Keyboard-centric users expect to be able to submit forms by pressing Enter, especially in single-input flows like auth code submission.

**📸 Before/After:**
- Before: Primary buttons ('Run', 'Authenticate') blended in with secondary actions. Auth code input could expand infinitely. No Enter-key submission for auth.
- After: Primary buttons are distinctly styled. Auth code input remains a single line. Enter-key submits the auth code. (See attached verification screenshots/video).

**♿ Accessibility:**
- Improved keyboard navigation by allowing Enter-key submission for the authorization code input, reducing reliance on pointer devices.
- Enhanced visual contrast and clear identification of primary actions for users with cognitive or visual impairments.

---
*PR created automatically by Jules for task [364022028199723181](https://jules.google.com/task/364022028199723181) started by @haseeb-heaven*