### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix Command Injection Vulnerability

### DIFF
--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,9 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # Security: Explicitly pass shell=False across all platforms to prevent Command Injection vulnerabilities.
+                # Windows does not strictly require shell=True to execute sys.executable.
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `subprocess.run` was conditionally using `shell=True` on Windows (`shell=os.name == "nt"`) when executing a command array. This introduces Command Injection risks (Bandit B602/B603).
🎯 Impact: A malicious actor could potentially inject arbitrary commands if any element in the `cmd` array was derived from untrusted input and executed on a Windows system.
🔧 Fix: Changed `shell=os.name == "nt"` to `shell=False`. Python's `subprocess` handles array commands correctly without the shell on Windows, specifically for executing modules like `pytest` via `sys.executable`. Added a code comment to explain the security concern.
✅ Verification: Ran `bandit -r framework/task_runner.py` to ensure B602 is no longer flagged and verified test runner functionality.

---
*PR created automatically by Jules for task [2410891707610771256](https://jules.google.com/task/2410891707610771256) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test command execution consistency across platforms.
  * Strengthened subprocess security during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->