### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix sensitive token leakage in exception logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-20 - Exception Logging Exposes Sensitive Tokens
+**Vulnerability:** URLError logging in Telegram notification tools did not pass exceptions through the `redact_sensitive()` function, potentially writing secret API tokens into plaintext console output if network requests failed.
+**Learning:** URL exception types like `URLError` or `HTTPError` include the original requested URL in their `.reason` and `str()` representations. If the URL contains an embedded secret (e.g. `https://api.telegram.org/bot<TOKEN>/sendMessage`), printing the exception leaks the secret.
+**Prevention:** Wrap exception objects with the `redact_sensitive()` string scrubbing function before passing them to loggers or `print()`.

--- a/gws_assistant/tools/telegram.py
+++ b/gws_assistant/tools/telegram.py
@@ -83,10 +83,10 @@ def send_telegram(message, context=None):
         print("Telegram message sent.")
         return True
     except urllib.error.URLError as e:
-        print(f"Error sending Telegram message: {e}")
+        print(redact_sensitive(f"Error sending Telegram message: {e}"))
         return False
     except Exception as e:
-        print(f"Exception sending Telegram message: {e}")
+        print(redact_sensitive(f"Exception sending Telegram message: {e}"))
         return False
 
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: URLError logging in Telegram notification tools did not pass exceptions through the `redact_sensitive()` function. URL exception types include the original requested URL in their representation, causing them to leak secret API tokens (e.g. `https://api.telegram.org/bot<TOKEN>/sendMessage`) into plaintext console output if a network request fails.
🎯 Impact: If a network error occurs, the Telegram bot token could be exposed in standard output/logs, allowing attackers who can read logs to hijack the bot.
🔧 Fix: Wrapped the exception log messages in `gws_assistant/tools/telegram.py` with the `redact_sensitive()` string scrubbing function before passing them to `print()`.
✅ Verification: Ran `pytest tests/test_tools_telegram.py` locally and verified test success. Checked that secrets are correctly redacted using the existing `test_redact_sensitive` unit tests.

---
*PR created automatically by Jules for task [1029505100175757743](https://jules.google.com/task/1029505100175757743) started by @haseeb-heaven*