### PR TITLE
🎨 Palette: Primary actions and auth input UX improvements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Primary Actions and Input UX
+**Learning:** In Gradio applications, primary actions (like "Run" or "Authenticate") blend in with secondary actions unless explicitly styled. Textboxes for pasting tokens (like auth codes) stretch awkwardly without line constraints. Users also expect to submit single-line forms via the Enter key.
+**Action:** Used `variant="primary"` on primary buttons, added `max_lines=1` to the auth token input, and bound `.submit()` to the token input to support Enter-key submissions.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
+                    max_lines=1,
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +304,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)
@@ -387,6 +388,18 @@ def create_interface() -> gr.Blocks:
         )
 
         submit_auth_button.click(
+            fn=on_auth_submit,
+            inputs=[client_config_state, auth_code_input],
+            outputs=[
+                credentials_file_state,
+                auth_status,
+                auth_code_input,
+                regenerate_url_button,
+                auth_message
+            ]
+        )
+
+        auth_code_input.submit(
             fn=on_auth_submit,
             inputs=[client_config_state, auth_code_input],
             outputs=[


### PR DESCRIPTION
* 💡 What: Used `variant="primary"` on the Run and Authenticate buttons. Added `max_lines=1` to the authorization code input. Bound the `.submit()` event to the authorization code input.
* 🎯 Why: Primary actions should be clearly distinguished from secondary ones to improve discoverability. The authorization code input should not awkwardly stretch when a long token is pasted, and users expect to submit single-line token inputs by pressing Enter.
* 📸 Before/After: Visual update to buttons.
* ♿ Accessibility: Improved keyboard navigation by allowing users to submit the auth code via the Enter key.

---
*PR created automatically by Jules for task [12045517039389764022](https://jules.google.com/task/12045517039389764022) started by @haseeb-heaven*