### PR TITLE
🛡️ Sentinel: [HIGH] Fix subprocess command injection vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-27 - [Fix subprocess command injection risk on Windows]
+**Vulnerability:** Found `subprocess.run` with `shell=os.name == "nt"` in `framework/task_runner.py`.
+**Learning:** `subprocess.run` with a command list (e.g., executing Python modules or scripts) does not strictly require `shell=True` on Windows when invoking `sys.executable`. Passing `shell=True` introduces a command injection vulnerability (and triggers Bandit B602 alerts).
+**Prevention:** Always explicitly pass `shell=False` to `subprocess.run` when passing a list of arguments, across all platforms.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,8 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # shell=False prevents command injection on Windows
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: `subprocess.run` was called with `shell=os.name == "nt"`, setting `shell=True` on Windows.
* 🎯 Impact: Allows command injection if any un-sanitized variables end up in the arguments.
* 🔧 Fix: Set `shell=False` for all platforms because invoking `sys.executable` as a list does not require a shell wrapper.
* ✅ Verification: Bandit scan confirms B602 is resolved. Test suite confirms no functionality broken.

---
*PR created automatically by Jules for task [2382036988054383954](https://jules.google.com/task/2382036988054383954) started by @haseeb-heaven*