### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection vulnerability in subprocess call

### DIFF
--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,8 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # 🛡️ Sentinel: Enforce shell=False to prevent command injection risks. Windows can execute sys.executable without it.
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `subprocess.run` call in `framework/task_runner.py` uses `shell=os.name == "nt"`, which introduces a command injection risk on Windows systems.
🎯 Impact: If user input is passed into the command arguments, it could allow an attacker to execute arbitrary shell commands on the host operating system.
🔧 Fix: Explicitly pass `shell=False` to `subprocess.run` to prevent shell injection, as Windows does not strictly require `shell=True` to execute binaries like `sys.executable`.
✅ Verification: Executed the test suite safely and validated that the Bandit B602 warning is resolved.

---
*PR created automatically by Jules for task [16028145370318330270](https://jules.google.com/task/16028145370318330270) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test execution consistency by disabling shell interpretation when running tests.
  * Reduced platform-specific behavior during test commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->