### PR TITLE
🎨 Palette: [UX improvement] Polish UI buttons and inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-10-24 - Gradio Input and Button Polish
+**Learning:** In Gradio applications, primary actions aren't visually distinct by default, and single-line token inputs can awkwardly stretch layout if pasted long tokens without max_lines restrictions. Also, users expect 'Enter' to submit forms on text inputs.
+**Action:** Use `variant="primary"` for main action buttons (Run, Authenticate), `max_lines=1` for token/code textboxes to prevent layout shifts, and always bind `.submit()` events to text inputs for keyboard accessibility.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
+                    max_lines=1,
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +304,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)
@@ -376,6 +377,18 @@ def create_interface() -> gr.Blocks:
                 submit_auth_button,
                 regenerate_url_button,
                 auth_message,
+                auth_message
+            ]
+        )
+
+        auth_code_input.submit(
+            fn=on_auth_submit,
+            inputs=[client_config_state, auth_code_input],
+            outputs=[
+                credentials_file_state,
+                auth_status,
+                auth_code_input,
+                regenerate_url_button,
                 auth_message
             ]
         )


### PR DESCRIPTION
💡 What: Set `variant="primary"` on Run and Authenticate buttons. Restricted auth code input to `max_lines=1`. Bound `.submit()` event to auth code input.
🎯 Why: Makes primary actions visually distinct and prevents awkward layout stretching from long authorization tokens, while improving keyboard accessibility by natively allowing users to press 'Enter' to submit the auth code.
📸 Before/After: Verified via Playwright.
♿ Accessibility: Added Enter-to-submit functionality on textboxes.

---
*PR created automatically by Jules for task [9589551721232747724](https://jules.google.com/task/9589551721232747724) started by @haseeb-heaven*