### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix sensitive data exposure in Telegram error logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-23 - Prevent sensitive data leakage in urllib exception handling
+**Vulnerability:** Unhandled `urllib.error.URLError` and generic `Exception` blocks in `gws_assistant/tools/telegram.py` cast the exception object to a string when printing it. If an HTTP error occurs (e.g., HTTP 404 with a token in the URL path, or HTTP 401 with a sensitive URL), the string representation of the exception can leak the requested URL (and the token within it) to logs.
+**Learning:** Implicit string conversions of network exceptions can leak request URLs containing tokens.
+**Prevention:** Always wrap the exception object with `redact_sensitive(e)` before printing/logging it to ensure any embedded tokens are redacted.

--- a/gws_assistant/tools/telegram.py
+++ b/gws_assistant/tools/telegram.py
@@ -83,10 +83,10 @@ def send_telegram(message, context=None):
         print("Telegram message sent.")
         return True
     except urllib.error.URLError as e:
-        print(f"Error sending Telegram message: {e}")
+        print(f"Error sending Telegram message: {redact_sensitive(e)}")
         return False
     except Exception as e:
-        print(f"Exception sending Telegram message: {e}")
+        print(f"Exception sending Telegram message: {redact_sensitive(e)}")
         return False
 
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Exceptions thrown by urllib (like URLError) during Telegram API calls were being cast to strings in print statements without redaction. These exceptions often include the full request URL, which for Telegram API endpoints includes the bot token embedded directly in the path (`https://api.telegram.org/bot<TOKEN>/sendMessage`). This unintentionally leaks the secret token to stdout/logs.
🎯 **Impact:** If these logs are captured, forwarded, or observed, the Telegram Bot Token is exposed in plaintext. This could lead to complete unauthorized access to the bot, allowing attackers to read/send messages masquerading as the application.
🔧 **Fix:** Wrapped the exception objects `e` within the exception handler print statements with `redact_sensitive(e)` to automatically scrub any known patterns or environment variable secrets (like `TELEGRAM_BOT_TOKEN`) before outputting the exception string.
✅ **Verification:** Ran the existing tests `pytest tests/test_tools_telegram.py tests/test_telegram_script.py` successfully. Also wrote and executed a targeted mock test script that simulated an HTTP error using a dummy token, confirming the `[REDACTED]` mask is correctly applied.

---
*PR created automatically by Jules for task [18318929157080565258](https://jules.google.com/task/18318929157080565258) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for Telegram delivery failures by masking sensitive information, including tokens and URLs, in displayed error messages.
* **Documentation**
  * Added a security note documenting the sensitive-data redaction safeguards for error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->