### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection vulnerability in subprocess call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2024-07-24 - [CRITICAL] Command Injection Vulnerability in Task Runner
+
+**Vulnerability:** subprocess.run is called with `shell=os.name == "nt"` which opens up command injection vulnerabilities on Windows.
+**Learning:** `shell=True` was likely added as a convenience/assumption for Windows compatibility but is rarely actually required when passing lists of arguments.
+**Prevention:** Always use `shell=False` for all platforms unless strictly required to invoke shell-specific features (and in those cases use extreme caution with user input).

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `subprocess.run` was called with `shell=os.name == "nt"`, allowing potential command injection on Windows platforms.
🎯 Impact: If arguments were user-controlled, an attacker could execute arbitrary OS commands.
🔧 Fix: Changed to `shell=False` to pass arguments safely as a list across all OS environments.
✅ Verification: Bandit scan confirms B602 is resolved; tests run successfully.

---
*PR created automatically by Jules for task [1321925639175190145](https://jules.google.com/task/1321925639175190145) started by @haseeb-heaven*