### PR TITLE
🎨 Palette: Primary Actions and Token Pasting

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-24 - Primary Actions and Token Pasting
+**Learning:** In Gradio applications, primary actions (like "Run" or "Authenticate") blend in with secondary actions if they don't have a distinct variant. Additionally, long authentication tokens pasted into `Textbox` components cause awkward layout stretching if `max_lines` is not constrained to 1, and users expect to be able to submit tokens by pressing Enter instead of just clicking the button.
+**Action:** Use `variant="primary"` on primary `gr.Button` elements, set `max_lines=1` on textboxes intended for token pasting, and bind `.submit()` events to these textboxes to allow Enter-key submissions.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
-                    visible=False
+                    visible=False,
+                    max_lines=1
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", visible=False, variant="primary")
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +304,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)
@@ -376,6 +377,18 @@ def create_interface() -> gr.Blocks:
                 submit_auth_button,
                 regenerate_url_button,
                 auth_message,
+                auth_message
+            ]
+        )
+
+        auth_code_input.submit(
+            fn=on_auth_submit,
+            inputs=[client_config_state, auth_code_input],
+            outputs=[
+                credentials_file_state,
+                auth_status,
+                auth_code_input,
+                regenerate_url_button,
                 auth_message
             ]
         )


### PR DESCRIPTION
💡 **What:** 
- Added `variant="primary"` to the `submit_auth_button` and `run_button` Gradio elements.
- Set `max_lines=1` on the `auth_code_input` Textbox.
- Bound the `.submit()` event to `auth_code_input` so the token can be submitted by pressing Enter.

🎯 **Why:** 
Primary actions like authenticating and running a task should stand out visually from secondary actions (like "Generate New Auth URL" or "Clear") so users know what to click next. Additionally, when a user pastes a long, multi-line OAuth token into the textbox, the UI can stretch awkwardly. Setting `max_lines=1` ensures a clean, single-line presentation. Finally, adding `.submit()` behavior allows a much smoother keyboard-driven flow where users can paste their code and immediately hit Enter to authenticate.

📸 **Before/After:**
*(Screenshots were captured and verified during local Playwright testing).*

♿ **Accessibility:**
- Better visual hierarchy with primary colors draws attention to the most important buttons, helping users with cognitive load navigate the interface.
- Keyboard support (submitting on Enter) means users utilizing keyboard navigation or screen readers do not have to manually tab to the "Authenticate" button to submit their code.

---
*PR created automatically by Jules for task [7051920000504275803](https://jules.google.com/task/7051920000504275803) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated primary actions, including Authenticate and Run, with clearer visual emphasis.
  * Adjusted the authorization code field for a more compact layout.
  * Added Enter-key submission for authorization codes, so authentication no longer requires clicking the button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->