### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection vulnerability in task_runner

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-25 - [Command Injection via OS-specific Shell Argument]
+**Vulnerability:** `subprocess.run` was called with `shell=os.name == "nt"` when executing a command list.
+**Learning:** Developers mistakenly believe Windows requires `shell=True` to execute binaries like `sys.executable`. This creates a command injection vulnerability and triggers Bandit B602 alerts.
+**Prevention:** Always explicitly pass `shell=False` for `subprocess.run` when using a command list, regardless of the operating system.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `subprocess.run` command in `framework/task_runner.py` used `shell=os.name == "nt"`, which introduces a command injection risk on Windows systems since `cmd` is a list, and Bandit flags this as a B602 alert.
🎯 Impact: If malicious data enters the command pipeline, it could be executed as a shell command on Windows systems.
🔧 Fix: Explicitly passed `shell=False` to `subprocess.run` to guarantee the command is never run through a shell wrapper on any platform.
✅ Verification: Tests run successfully, validating that pytest is correctly invoked without requiring `shell=True` on Windows.

---
*PR created automatically by Jules for task [2218641983838433492](https://jules.google.com/task/2218641983838433492) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test execution security by preventing shell injection risks when running pytest commands.
  * Standardized command handling across operating systems while preserving existing timeout, retry, and error behavior.

* **Documentation**
  * Added security guidance covering safe subprocess usage and command injection prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->