### PR TITLE
🎨 Palette: Gradio UX improvements for buttons and forms

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## $(date +%Y-%m-%d) - Gradio Form UX Improvements
+**Learning:** In Gradio applications, primary actions (like "Run" or "Authenticate") blend in with secondary actions unless explicitly styled. Additionally, users expect standard form behaviors, such as pressing Enter to submit and single-line inputs for tokens.
+**Action:** Use `variant="primary"` on primary `gr.Button` elements, bind `.submit()` events to `gr.Textbox` inputs to allow Enter-key submissions, and use `max_lines=1` on textboxes intended for pasting long tokens to prevent awkward layout stretching.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
-                    visible=False
+                    visible=False,
+                    max_lines=1
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +304,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)
@@ -376,6 +377,18 @@ def create_interface() -> gr.Blocks:
                 submit_auth_button,
                 regenerate_url_button,
                 auth_message,
+                auth_message
+            ]
+        )
+
+        auth_code_input.submit(
+            fn=on_auth_submit,
+            inputs=[client_config_state, auth_code_input],
+            outputs=[
+                credentials_file_state,
+                auth_status,
+                auth_code_input,
+                regenerate_url_button,
                 auth_message
             ]
         )


### PR DESCRIPTION
### 💡 What
Added `variant="primary"` to the "Authenticate" and "Run" buttons to make them visually distinct from secondary actions like "Clear" or "Generate New Auth URL". Additionally, forced the `auth_code_input` textbox to be single-line (`max_lines=1`) and bound an `.submit()` event to it.

### 🎯 Why
In complex forms, primary actions should stand out to guide the user's eye and indicate the most important next step. Without explicit styling, primary actions in Gradio blend in with secondary or destructive actions. Setting `max_lines=1` prevents the token input field from awkwardly expanding when users paste long OAuth tokens. The `.submit()` event handler allows users to simply hit "Enter" after pasting their token, matching standard web form expectations and providing a smoother authentication flow.

### 📸 Before/After
*(Visuals verified via Playwright headless screenshot during development)*
**Before:** All buttons had the same secondary visual weight. The authorization code input lacked enter-to-submit functionality and would stretch vertically for long inputs.
**After:** The "Run" and "Authenticate" buttons are now highlighted in the primary theme color. The authorization code input remains a compact single line and submits instantly on Enter.

### ♿ Accessibility
Adding clear visual distinction to primary actions helps users with cognitive disabilities more easily identify the main path forward in the UI. Binding the "Enter" key to the form submission improves keyboard navigation accessibility by reducing reliance on tabbing to and clicking a specific button.

---
*PR created automatically by Jules for task [1290982979701680811](https://jules.google.com/task/1290982979701680811) started by @haseeb-heaven*