### PR TITLE
🎨 Palette: [UX improvement]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Gradio Interactive Elements Enhancements
+**Learning:** Textboxes used for single-line tokens can stretch awkwardly in Gradio. Primary action buttons blend in with secondary actions if not explicitly marked. Users expect Enter to submit forms.
+**Action:** Set `max_lines=1` on token textboxes. Use `variant="primary"` on primary buttons. Bind `.submit()` event to textboxes to mirror primary action clicks.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
-                    visible=False
+                    visible=False,
+                    max_lines=1
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +304,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)
@@ -376,6 +377,18 @@ def create_interface() -> gr.Blocks:
                 submit_auth_button,
                 regenerate_url_button,
                 auth_message,
+                auth_message
+            ]
+        )
+
+        auth_code_input.submit(
+            fn=on_auth_submit,
+            inputs=[client_config_state, auth_code_input],
+            outputs=[
+                credentials_file_state,
+                auth_status,
+                auth_code_input,
+                regenerate_url_button,
                 auth_message
             ]
         )


### PR DESCRIPTION
**💡 What**
Added `variant="primary"` to the main `Authenticate` and `Run` buttons to make them stand out from secondary actions (like `Generate New Auth URL` or `Clear`). Configured the `auth_code_input` textbox to have `max_lines=1` so that pasting a single long authentication string doesn't vertically stretch the input awkwardly. Finally, bound the `.submit()` event to the auth code input so users can press 'Enter' instead of having to explicitly click the 'Authenticate' button.

**🎯 Why**
- **Clarity:** Primary actions were blending in with secondary buttons, causing slight cognitive load when choosing what to click.
- **Form UX:** Users intuitively expect to hit 'Enter' after typing or pasting a code. Not supporting this was an interaction bottleneck.
- **Layout:** Without `max_lines=1`, Gradio allowed the auth token textbox to grow based on the token's length, pushing other elements down unnecessarily and making the layout feel unpolished.

**📸 Before/After**
*Before:*
- All buttons were gray (secondary style).
- The Auth Code input would expand if a multi-line or long token was pasted.
- Hitting enter in the auth code box did nothing.

*After:*
- The Authenticate and Run buttons are visually highlighted (primary style).
- The Auth Code input strictly remains one line.
- Hitting enter submits the auth code successfully.

**♿ Accessibility**
The `variant="primary"` change inherently improves visual contrast and keyboard focus visibility for the main actions. Allowing the `.submit()` action directly from the textbox reduces the need for unnecessary mouse navigation for screen reader or keyboard-only users.

---
*PR created automatically by Jules for task [3445081430896477657](https://jules.google.com/task/3445081430896477657) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pressing Enter in the authorization code field now submits the authentication form.
* **UI Improvements**
  * Authorization code input is limited to a single line.
  * The primary “Run” action is now visually highlighted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->