### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Command Injection risk (Bandit B602) in task runner

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-26 - Fix Command Injection risk (Bandit B602) in task runner
+**Vulnerability:** `subprocess.run` was called with `shell=os.name == "nt"` in `framework/task_runner.py` while passing an argument list.
+**Learning:** This is a Command Injection risk on Windows because `shell=True` causes the argument list to be converted to a string and executed in `cmd.exe`.
+**Prevention:** Always use `shell=False` across all platforms (including Windows) when executing binaries directly (e.g. `sys.executable`). Windows does not strictly require `shell=True` to execute binaries.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential Command Injection risk due to `shell=True` (or dynamically evaluating to True) in `subprocess.run`.
🎯 Impact: A malicious payload in variables like `self.service` (used in `marker_expr` and subsequently in `cmd`) could be executed as a shell command on Windows.
🔧 Fix: Changed `shell=os.name == "nt"` to `shell=False`. Executing `sys.executable` does not require a shell, even on Windows.
✅ Verification: Run `bandit -r framework/task_runner.py` to ensure no B602 alerts are reported and run the test suite to verify no regressions in execution functionality.

---
*PR created automatically by Jules for task [15111249281376733606](https://jules.google.com/task/15111249281376733606) started by @haseeb-heaven*