### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection vulnerability in subprocess call

### DIFF
--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `subprocess.run` call in `framework/task_runner.py` was passing `shell=os.name == "nt"` when executing a command provided as a list. Using `shell=True` with command lists can lead to command injection vulnerabilities.
🎯 Impact: An attacker could potentially inject malicious commands if any part of the command list were controllable, leading to unauthorized code execution.
🔧 Fix: Explicitly set `shell=False` across all platforms, as Windows does not require `shell=True` to execute binaries like `sys.executable`.
✅ Verification: Ran Bandit security scanner to confirm the B602 issue is resolved and executed unit tests for the runner (`pytest tests/test_runner.py`) to ensure no regressions.

---
*PR created automatically by Jules for task [9545517632099507723](https://jules.google.com/task/9545517632099507723) started by @haseeb-heaven*