### PR TITLE
🎨 Palette: [UX improvement] Primary actions and form submission

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - [Primary Actions and Enter Key Submissions in Gradio]
+**Learning:** Primary buttons and single-line text inputs (with Enter key submission) significantly improve the flow of authentication forms and main action triggers in Gradio applications, preventing layout stretching and confusing secondary actions.
+**Action:** Always use `variant="primary"` for primary actions (like Submit/Run), add `max_lines=1` for token/code inputs, and bind `.submit()` events to textboxes that serve as form inputs.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
-                    visible=False
+                    visible=False,
+                    max_lines=1
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", visible=False, variant="primary")
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +304,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)
@@ -376,6 +377,18 @@ def create_interface() -> gr.Blocks:
                 submit_auth_button,
                 regenerate_url_button,
                 auth_message,
+                auth_message
+            ]
+        )
+
+        auth_code_input.submit(
+            fn=on_auth_submit,
+            inputs=[client_config_state, auth_code_input],
+            outputs=[
+                credentials_file_state,
+                auth_status,
+                auth_code_input,
+                regenerate_url_button,
                 auth_message
             ]
         )


### PR DESCRIPTION
💡 **What**: Added `variant="primary"` to primary action buttons (Run and Authenticate), restricted the Auth Code input to 1 line, and enabled Enter key submission for the Auth Code input.
🎯 **Why**: Differentiates primary actions from secondary ones, prevents large codes from unexpectedly stretching the layout, and provides a smoother, more intuitive form submission flow (using Enter instead of clicking).
📸 **Before/After**: Visually verified.
♿ **Accessibility**: Better focus flow and interaction model by allowing standard keyboard submission for the text input.

---
*PR created automatically by Jules for task [11617939159655570180](https://jules.google.com/task/11617939159655570180) started by @haseeb-heaven*