### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command Injection vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [subprocess.run Command Injection Risk]
+**Vulnerability:** subprocess call with shell=True on Windows identified, command injection vulnerability (Bandit B602).
+**Learning:** Using `shell=os.name == "nt"` introduces a severe command injection vulnerability on Windows systems. Windows does not strictly require `shell=True` to execute binaries like `sys.executable`.
+**Prevention:** Always explicitly pass `shell=False` when invoking `subprocess.run` with a command list across all platforms to prevent command injection vulnerabilities.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Command injection vulnerability due to `shell=os.name == "nt"` in `subprocess.run` on Windows.
🎯 Impact: An attacker could potentially inject malicious commands if `cmd` contents were influenced by user input on Windows environments.
🔧 Fix: Hardcoded `shell=False` for all platforms in `framework/task_runner.py` when invoking `subprocess.run` with a command list, mitigating the command injection risk.
✅ Verification: Ensured Bandit B602 check passes and confirmed tests in `tests/test_runner.py` are functioning properly.

---
*PR created automatically by Jules for task [7176280019404549370](https://jules.google.com/task/7176280019404549370) started by @haseeb-heaven*