### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection vulnerability in subprocess call

### DIFF
--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `subprocess.run` call in `framework/task_runner.py` used `shell=os.name == "nt"`, resulting in `shell=True` on Windows. This opens the potential for command injection if inputs are not fully sanitized.
🎯 Impact: If user input reaches this command array, it could allow arbitrary command execution on the host system.
🔧 Fix: Hardcoded `shell=False` to securely execute commands cross-platform without invoking a system shell.
✅ Verification: Run `bandit -r framework/task_runner.py` and verify `B602` is no longer flagged.

---
*PR created automatically by Jules for task [12516260504614315251](https://jules.google.com/task/12516260504614315251) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test execution consistency across supported platforms.
  * Preserved existing test output capture, timeout, and success/failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->