### PR TITLE
🎨 Palette: Improve button visual hierarchy and token input UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-29 - Improve button visual hierarchy and token input UX
+**Learning:** In Gradio applications, primary actions (like "Run" or "Authenticate") can blend in with secondary actions (like "Clear") leading to a less intuitive experience. Additionally, token/code inputs should restrict line growth to avoid layout awkwardness, and forms feel broken if "Enter" doesn't submit.
+**Action:** Always apply `variant="primary"` to primary action buttons. Add `max_lines=1` to inputs meant for short strings or codes. Bind `.submit()` events on textboxes to matching button click actions for better keyboard accessibility.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
-                    visible=False
+                    visible=False,
+                    max_lines=1
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +304,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)
@@ -387,6 +388,18 @@ def create_interface() -> gr.Blocks:
         )
 
         submit_auth_button.click(
+            fn=on_auth_submit,
+            inputs=[client_config_state, auth_code_input],
+            outputs=[
+                credentials_file_state,
+                auth_status,
+                auth_code_input,
+                regenerate_url_button,
+                auth_message
+            ]
+        )
+
+        auth_code_input.submit(
             fn=on_auth_submit,
             inputs=[client_config_state, auth_code_input],
             outputs=[


### PR DESCRIPTION
### 💡 What
Added `variant="primary"` to the "Authenticate" and "Run" buttons.
Added `max_lines=1` to the authorization code input.
Bound the `.submit()` event on the authorization code textbox to support pressing "Enter" to submit.

### 🎯 Why
Primary actions (like "Run" or "Authenticate") can blend in with secondary actions (like "Clear") leading to a less intuitive experience. Additionally, token/code inputs should restrict line growth to avoid layout awkwardness, and forms feel broken if "Enter" doesn't submit.

### 📸 Before/After
*(Screenshots showing the updated visual hierarchy with primary buttons and improved input constraints have been captured and verified locally during testing)*

### ♿ Accessibility
Binding the `.submit()` event on the `Textbox` greatly improves keyboard accessibility by allowing users to simply press "Enter" after pasting their token, rather than requiring them to tab to or click the "Authenticate" button. Adding `variant="primary"` provides better visual cues and contrast for the main calls to action on the interface.

---
*PR created automatically by Jules for task [16479121761247037707](https://jules.google.com/task/16479121761247037707) started by @haseeb-heaven*