### PR TITLE
🛡️ Sentinel: [HIGH] Fix sensitive token leak in URL exceptions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-18 - Fix sensitive token leak in URL exceptions
+**Vulnerability:** When the Telegram API returns an error (e.g. `urllib.error.URLError`), the exception string might contain the requested URL, which embeds the `TELEGRAM_BOT_TOKEN`. Printing it raw leaks the secret to the console/logs.
+**Learning:** Even built-in exception types can leak sensitive information if they contain the URL, requiring explicit redaction before logging.
+**Prevention:** Always wrap exception variables with a redaction function (like `redact_sensitive(e)`) when catching errors that might contain URLs or other secrets, especially around network requests.

--- a/gws_assistant/tools/telegram.py
+++ b/gws_assistant/tools/telegram.py
@@ -83,10 +83,10 @@ def send_telegram(message, context=None):
         print("Telegram message sent.")
         return True
     except urllib.error.URLError as e:
-        print(f"Error sending Telegram message: {e}")
+        print(f"Error sending Telegram message: {redact_sensitive(e)}")
         return False
     except Exception as e:
-        print(f"Exception sending Telegram message: {e}")
+        print(f"Exception sending Telegram message: {redact_sensitive(e)}")
         return False
 
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: When the Telegram API returns an error (e.g. `urllib.error.URLError`), the exception string might contain the requested URL, which embeds the `TELEGRAM_BOT_TOKEN`. Printing it raw leaks the secret to the console/logs.
🎯 Impact: Leaking the Telegram bot token could allow an attacker to hijack the bot, send spoofed messages, or access user data.
🔧 Fix: Wrapped the exception variables `e` with `redact_sensitive(e)` when printing errors.
✅ Verification: Ensured the test suite passes.

---
*PR created automatically by Jules for task [7501256660826768556](https://jules.google.com/task/7501256660826768556) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive information is now redacted from Telegram send-error messages, including details that may appear in request URLs.
  * Successful message delivery and return behavior remain unchanged.

* **Documentation**
  * Added guidance on preventing sensitive data exposure in network request error logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->