### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in task_runner

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-24 - Command Injection Risk in Cross-Platform Shell Execution
+**Vulnerability:** `subprocess.run` was called with `shell=os.name == "nt"` which evaluates to `True` on Windows, exposing a command injection vulnerability (Bandit B602).
+**Learning:** Windows does not strictly require `shell=True` to execute commands passed as a list (like `sys.executable`). Setting it to `True` unnecessarily opens up shell injection risks if argument inputs aren't perfectly sanitized.
+**Prevention:** Always explicitly pass `shell=False` to `subprocess` functions when passing command lists, regardless of the operating system (Windows/Linux/macOS), unless specifically executing built-in shell commands.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** `subprocess.run` in `framework/task_runner.py` was executed with `shell=os.name == "nt"`, which evaluates to `True` on Windows. When `shell=True` is combined with variables passed from user contexts or test environment configurations (Bandit B602), it can permit shell metacharacter injection.
🎯 **Impact:** If malicious input is passed into the command list configuration, it could allow an attacker to execute arbitrary shell commands directly on the host operating system.
🔧 **Fix:** Hardcoded `shell=False` across all platforms since passing explicit argument lists (like `[sys.executable, "-m", "pytest"...]`) to `subprocess.run` does not require a shell wrapper. Added entry to `.jules/sentinel.md` noting cross-platform differences in shell processing.
✅ **Verification:** Verified locally that the change runs tests securely. Executing Bandit (`bandit -r framework/task_runner.py -f json`) confirms zero B602 (shell=True) findings.

---
*PR created automatically by Jules for task [674387705304074792](https://jules.google.com/task/674387705304074792) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows security by preventing shell command injection when running automated tests.
  * Test commands now execute directly without invoking the system shell.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->