### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Telegram token leakage in error logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-11-20 - Token Leakage in Exception Logs
+**Vulnerability:** The Telegram bot token is embedded in the URL. If the API request fails, printing the exception (e.g. `urllib.error.URLError`) exposes the full URL, leaking the bot token in plain text in the system logs.
+**Learning:** The URL-based authentication mechanisms inherently embed secrets into request metadata. Default exception string representations for network libraries often include the attempted URL.
+**Prevention:** Always wrap exception objects with a secret redaction function (like `redact_sensitive()`) before printing or logging them when the request involves URLs with embedded tokens.

--- a/gws_assistant/tools/telegram.py
+++ b/gws_assistant/tools/telegram.py
@@ -83,10 +83,10 @@ def send_telegram(message, context=None):
         print("Telegram message sent.")
         return True
     except urllib.error.URLError as e:
-        print(f"Error sending Telegram message: {e}")
+        print(f"Error sending Telegram message: {redact_sensitive(e)}")
         return False
     except Exception as e:
-        print(f"Exception sending Telegram message: {e}")
+        print(f"Exception sending Telegram message: {redact_sensitive(e)}")
         return False
 
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: When `urllib.error.URLError` or a general `Exception` occurs during a Telegram API call, printing the exception directly leaks the full URL. Since the bot token is embedded in the URL, this exposes the token in plain text within the logs.
🎯 Impact: If these logs are ingested into a monitoring system or viewed by unauthorized users, an attacker could steal the bot token and hijack or impersonate the Telegram bot.
🔧 Fix: Wrapped the exception objects `e` with `redact_sensitive(e)` before printing them to ensure any embedded tokens are safely redacted.
✅ Verification: Ran the test suite for the telegram tool and verified code modification manually.

---
*PR created automatically by Jules for task [3946296948342018318](https://jules.google.com/task/3946296948342018318) started by @haseeb-heaven*