### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection vulnerability on Windows

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-27 - [Fix OS Command Injection via shell=True in subprocess.run]
+**Vulnerability:** Found `subprocess.run(..., shell=os.name == "nt")` in `framework/task_runner.py` which allows command injection on Windows platforms.
+**Learning:** `shell=True` (or expressions that evaluate to it) with unsanitized/command list inputs opens up OS command injection vulnerabilities. `subprocess.run` accepts a list and doesn't strictly need `shell=True` to execute commands securely, even on Windows.
+**Prevention:** Explicitly pass `shell=False` across all platforms (including Windows) to prevent Command Injection vulnerabilities and avoid Bandit B602 alerts.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix command injection vulnerability on Windows

🚨 Severity: CRITICAL
💡 Vulnerability: `subprocess.run()` was using `shell=os.name == "nt"`, allowing potential OS command injection on Windows platforms when handling unsanitized inputs.
🎯 Impact: If malicious input is passed into the command list on Windows, the shell evaluation could execute arbitrary commands.
🔧 Fix: Explicitly enforced `shell=False` across all platforms to prevent shell expansion, as `subprocess.run` accepts a command list directly and doesn't require the shell on Windows.
✅ Verification: Run `bandit -r framework/task_runner.py` to verify `B602` (subprocess_popen_with_shell_equals_true) is cleared, and execute `pytest tests/` to verify tests still pass.

---
*PR created automatically by Jules for task [15753223751580033580](https://jules.google.com/task/15753223751580033580) started by @haseeb-heaven*