### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command Injection vulnerability in task_runner.py

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-08-07 - Avoid shell=True for sys.executable in subprocess
+**Vulnerability:** Subprocess command execution with shell=True when passing a list of arguments for `sys.executable`. (Bandit B602)
+**Learning:** The code used `shell=os.name == "nt"` which unnecessarily activated the shell on Windows. Windows does not strictly require `shell=True` to execute binaries like `sys.executable`. Passing a list of arguments with `shell=True` is dangerous and flagged as a HIGH risk for Command Injection.
+**Prevention:** Explicitly pass `shell=False` across all platforms (including Windows) when invoking `subprocess.run` with a command list to prevent Command Injection vulnerabilities and avoid Bandit B602 alerts.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Using `subprocess.run` with `shell=True` (on Windows) while passing a command list (`[sys.executable, ...]`) allows potential Command Injection if any argument contains shell metacharacters.
🎯 Impact: A malicious payload in the test environment could execute arbitrary shell commands.
🔧 Fix: Explicitly set `shell=False` across all platforms. Windows does not need `shell=True` to execute Python with `sys.executable`.
✅ Verification: Run `bandit -r .` and confirm the B602 warning in `framework/task_runner.py` is removed. Run `pytest` to confirm test executions still work smoothly on all OS.

---
*PR created automatically by Jules for task [17108984260888391358](https://jules.google.com/task/17108984260888391358) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test execution reliability on Windows by running commands without the system shell.
  * Addressed a security warning related to subprocess command execution.
* **Documentation**
  * Added guidance clarifying secure subprocess usage across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->