### PR TITLE
🎨 Palette: Improve Gradio actions and input ergonomics

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Gradio Primary Actions & Input Ergonomics
+**Learning:** Users pasting long auth tokens often experience awkward layout stretching, and primary actions are easily confused with secondary ones.
+**Action:** Apply `variant="primary"` to primary buttons (Authenticate, Run), use `max_lines=1` for single-line inputs like tokens, and bind `.submit()` for Enter-key submission on inputs.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
-                    visible=False
+                    visible=False,
+                    max_lines=1
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", visible=False, variant="primary")
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +304,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)
@@ -376,6 +377,18 @@ def create_interface() -> gr.Blocks:
                 submit_auth_button,
                 regenerate_url_button,
                 auth_message,
+                auth_message
+            ]
+        )
+
+        auth_code_input.submit(
+            fn=on_auth_submit,
+            inputs=[client_config_state, auth_code_input],
+            outputs=[
+                credentials_file_state,
+                auth_status,
+                auth_code_input,
+                regenerate_url_button,
                 auth_message
             ]
         )


### PR DESCRIPTION
💡 What: Added `variant="primary"` to primary actions (Authenticate, Run), applied `max_lines=1` to the authorization code input, and bound a `.submit()` event to allow Enter-key submission for the token.
🎯 Why: Long tokens awkwardly stretched the UI layout, and primary buttons blended in with secondary buttons. Binding `.submit()` also improves keyboard ergonomics so users don't have to reach for their mouse after pasting.
📸 Before/After: Verified visually via Playwright screenshot; buttons now pop with primary color, and the auth input remains a single line.
♿ Accessibility: Better visual hierarchy through standard button variants (primary vs default), which helps clarify primary actions. Keyboard-only users can now submit the auth code immediately via Enter.
📓 Journal: Created `.jules/palette.md` to document the learning that primary inputs in Gradio need `max_lines=1` for long string pasting, and submit bindings greatly improve keyboard workflow.

---
*PR created automatically by Jules for task [4260917597013030001](https://jules.google.com/task/4260917597013030001) started by @haseeb-heaven*