### PR TITLE
🎨 Palette: [UX improvement] Primary buttons and single-line token inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - [Preventing Layout Shift on Token Inputs]
+**Learning:** In Gradio applications, textboxes intended for pasting long, single-string tokens (like OAuth codes) can cause awkward layout stretching or unnecessary vertical expansion when users paste the code.
+**Action:** Use `max_lines=1` on token/code textboxes to preserve layout stability and prevent vertical shift upon paste.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
+                    max_lines=1,
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +304,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 **What:** Added `variant="primary"` to the main call-to-action buttons ("Authenticate" and "Run") in the Gradio web UI. Additionally, set `max_lines=1` on the `auth_code_input` Textbox.

🎯 **Why:** To improve visual hierarchy by making primary actions stand out from secondary buttons like "Clear". The `max_lines=1` change on the token input prevents awkward, unnecessary vertical layout stretching when users paste long OAuth authorization strings.

📸 **Before/After:** Before, the "Run" and "Clear" buttons had the same visual weight, and pasting long tokens would stretch the input field vertically. After, "Run" and "Authenticate" stand out with primary colors, and the input field maintains its layout.

♿ **Accessibility:** Improves cognitive accessibility by clearly defining the primary action path on the interface.

---
*PR created automatically by Jules for task [12404935206800482668](https://jules.google.com/task/12404935206800482668) started by @haseeb-heaven*