### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command Injection vulnerability

### DIFF
--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `subprocess.run` is called with `shell=os.name == "nt"`, which evaluates to `True` on Windows platforms. This is a potential command injection vulnerability (Bandit B602).
🎯 Impact: An attacker could potentially append malicious shell commands if any part of the command list contains untrusted input, leading to arbitrary code execution on Windows.
🔧 Fix: Explicitly set `shell=False` for all platforms. Windows does not strictly require `shell=True` to execute binaries like `sys.executable`.
✅ Verification: Run tests with `pytest tests/test_runner.py` to ensure the module still functions correctly and verify `shell=False` is set.

---
*PR created automatically by Jules for task [13449549436755227424](https://jules.google.com/task/13449549436755227424) started by @haseeb-heaven*