### PR TITLE
🎨 Palette: Improve primary actions and input ergonomics

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Improve authentication UX and primary buttons
+**Learning:** Users pasting long authorization codes in the Gradio textbox encounter awkward stretching, and primary actions lack visual distinction from secondary ones. Binding Enter-key submission to text inputs significantly improves flow.
+**Action:** Add `max_lines=1` to inputs intended for tokens, use `variant="primary"` for main action buttons, and bind `.submit()` events to inputs to enable keyboard submission.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
-                    visible=False
+                    visible=False,
+                    max_lines=1,
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +304,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)
@@ -387,6 +388,18 @@ def create_interface() -> gr.Blocks:
         )
 
         submit_auth_button.click(
+            fn=on_auth_submit,
+            inputs=[client_config_state, auth_code_input],
+            outputs=[
+                credentials_file_state,
+                auth_status,
+                auth_code_input,
+                regenerate_url_button,
+                auth_message
+            ]
+        )
+
+        auth_code_input.submit(
             fn=on_auth_submit,
             inputs=[client_config_state, auth_code_input],
             outputs=[


### PR DESCRIPTION
💡 What: Added `max_lines=1` to the authorization token input, changed primary buttons to `variant="primary"`, and bound the `.submit()` event to allow Enter-key submission for auth.
🎯 Why: Long authorization tokens previously caused the Gradio textbox to stretch awkwardly. Additionally, mapping the Enter key to the auth action allows a smoother, keyboard-driven flow, and primary buttons are now visually distinct from secondary ones.
📸 Before/After: (Screenshot verification available)
♿ Accessibility: Improves keyboard navigation by allowing Enter-key submission for forms instead of requiring a mouse click.

---
*PR created automatically by Jules for task [14671614014190280389](https://jules.google.com/task/14671614014190280389) started by @haseeb-heaven*