### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection vulnerability in subprocess call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [Fix Command Injection in Task Runner]
+**Vulnerability:** Command injection vulnerability in `subprocess.run` due to conditional `shell=True` on Windows (`shell=os.name == "nt"`).
+**Learning:** Hardcoding `shell=True` on Windows under the assumption that it is required for all `subprocess` execution is flawed. When invoking binary executables (like `sys.executable`), `shell=False` works perfectly fine and is required to avoid execution of shell metacharacters embedded in user input.
+**Prevention:** Always explicitly set `shell=False` across all operating systems when constructing explicit command arrays (`subprocess.run(["cmd", "arg"])`), especially when dynamic strings are appended to the array.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Command injection vulnerability in `subprocess.run` due to conditional `shell=True` on Windows (`shell=os.name == "nt"`).
🎯 Impact: If untrusted input were ever passed to `cmd`, it could allow arbitrary command execution on Windows environments.
🔧 Fix: Hardcoded `shell=False` as it is not necessary to execute `sys.executable` with `shell=True` on Windows.
✅ Verification: Run `tests/test_runner.py` using `pytest`.

---
*PR created automatically by Jules for task [5830542969013200891](https://jules.google.com/task/5830542969013200891) started by @haseeb-heaven*