### PR TITLE
🎨 Palette: [UX] Improve Gradio inputs and primary buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-11 - [UX] Improve Gradio component visual hierarchy and layout
+**Learning:** Using `variant="primary"` on primary Gradio buttons (like Run or Authenticate) clarifies the visual hierarchy, distinguishing them from secondary actions. Setting `max_lines=1` on text inputs designed for long, single-line tokens prevents awkward UI stretching when pasting. Binding `.submit()` to text inputs allows seamless Enter-key submission for better keyboard UX.
+**Action:** Apply `variant="primary"` to key action buttons, `max_lines=1` to token inputs, and bind `.submit()` events to inputs where users naturally press Enter.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
+                    max_lines=1,
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +304,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)
@@ -376,6 +377,18 @@ def create_interface() -> gr.Blocks:
                 submit_auth_button,
                 regenerate_url_button,
                 auth_message,
+                auth_message
+            ]
+        )
+
+        auth_code_input.submit(
+            fn=on_auth_submit,
+            inputs=[client_config_state, auth_code_input],
+            outputs=[
+                credentials_file_state,
+                auth_status,
+                auth_code_input,
+                regenerate_url_button,
                 auth_message
             ]
         )


### PR DESCRIPTION
- 💡 **What:** Added `variant="primary"` to main action buttons, set `max_lines=1` on token inputs, and bound `submit()` to allow Enter-key submissions in the Gradio UI.
- 🎯 **Why:** To distinguish primary actions visually from secondary ones and prevent awkward layout stretching when users paste long authorization tokens. Allow fast, seamless keyboard navigation.
- 📸 **Before/After:** N/A (Visuals verified via Playwright)
- ♿ **Accessibility:** Improved keyboard navigation flow by allowing Enter to submit the auth code, and improved visual focus/hierarchy.

---
*PR created automatically by Jules for task [1431893678471921940](https://jules.google.com/task/1431893678471921940) started by @haseeb-heaven*