### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection vulnerability in task_runner.py

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-08-12 - Fix Command Injection Vulnerability in task_runner.py
+**Vulnerability:** A `subprocess.run` call in `framework/task_runner.py` uses `shell=os.name == "nt"`. On Windows, this means `shell=True` when passing a list command arguments, which can be interpreted improperly by the shell and lead to command injection or unexpected execution. According to Bandit (B602), passing a list of arguments and `shell=True` can be dangerous and is explicitly discouraged. Windows does not strictly require `shell=True` to execute binaries like `sys.executable`.
+**Learning:** `subprocess.run` with a command list (e.g., executing Python modules or scripts) should explicitly pass `shell=False` across all platforms (including Windows) to prevent Command Injection vulnerabilities.
+**Prevention:** Avoid dynamic logic for `shell=` and default to `shell=False` everywhere. Ensure that tests validating logic are correctly decoupled from system commands.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
*   🚨 Severity: CRITICAL
*   💡 Vulnerability: `subprocess.run` was called with `shell=os.name == "nt"`, introducing potential command injection on Windows platforms when `cmd` is passed as a list.
*   🎯 Impact: Attackers could inject arbitrary shell commands if any part of the command list contains shell metacharacters.
*   🔧 Fix: Enforce `shell=False` for all `subprocess.run` calls, which is safe for executing the Python interpreter `sys.executable`.
*   ✅ Verification: `pytest tests/test_runner.py` passes and `bandit` no longer complains about `B602` for this file.

---
*PR created automatically by Jules for task [5834520851871203645](https://jules.google.com/task/5834520851871203645) started by @haseeb-heaven*