### PR TITLE
🎨 Palette: Improve Gradio Auth and Run button UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Primary Actions and Enter Key Submissions in Gradio
+**Learning:** Users naturally hit the "Enter" key after typing a code into an input field, but Gradio `gr.Textbox` does not trigger `gr.Button` clicks by default. Primary actions (like "Run" or "Authenticate") also visually blend with secondary actions ("Clear" or "Generate New") without a distinct `variant`. Setting `max_lines=1` on text inputs prevents the input from awkwardly expanding into a multi-line textarea when users paste long tokens.
+**Action:** Use `variant="primary"` on primary buttons. Always bind `.submit()` events to text inputs meant for short data (like tokens) and restrict them with `max_lines=1`.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
-                    visible=False
+                    visible=False,
+                    max_lines=1
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +304,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)
@@ -387,6 +388,18 @@ def create_interface() -> gr.Blocks:
         )
 
         submit_auth_button.click(
+            fn=on_auth_submit,
+            inputs=[client_config_state, auth_code_input],
+            outputs=[
+                credentials_file_state,
+                auth_status,
+                auth_code_input,
+                regenerate_url_button,
+                auth_message
+            ]
+        )
+
+        auth_code_input.submit(
             fn=on_auth_submit,
             inputs=[client_config_state, auth_code_input],
             outputs=[


### PR DESCRIPTION
* 💡 What: Added `variant="primary"` to main action buttons ("Run" and "Authenticate"), restricted the auth code input to single line (`max_lines=1`), and bound Enter key to submit the auth code.
* 🎯 Why: Primary actions should be visually distinct from secondary ones. Users pasting long tokens shouldn't see awkwardly stretching textareas. Users naturally hit "Enter" after typing a code.
* 📸 Before/After: Buttons now stand out with solid fill.
* ♿ Accessibility: Improved keyboard accessibility (Enter to submit code).

---
*PR created automatically by Jules for task [17028303342753314879](https://jules.google.com/task/17028303342753314879) started by @haseeb-heaven*