### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix Command Injection vulnerability in framework/task_runner.py

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Command Injection Risk with Conditional Shell Execution
+**Vulnerability:** Subprocess calls conditionally using `shell=True` on Windows (`shell=os.name == "nt"`) without safe input handling.
+**Learning:** Using `shell=True` even selectively (like only on Windows) opens the application to Command Injection vulnerabilities. Windows doesn't require `shell=True` to execute binaries like `sys.executable`.
+**Prevention:** Always use `shell=False` across all platforms when passing a list of arguments to `subprocess.run()`.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `subprocess.run` was called conditionally with `shell=os.name == "nt"`, executing arguments through the shell on Windows, creating a potential command injection risk.
🎯 **Impact:** A malicious actor could execute arbitrary shell commands if untrusted input ever reaches the `subprocess.run` arguments on a Windows environment.
🔧 **Fix:** Explicitly set `shell=False` across all platforms. Windows does not strictly require `shell=True` to safely execute lists of arguments containing binaries like `sys.executable`.
✅ **Verification:** Ran `pytest tests/test_runner.py` and validated that the module successfully initiates and tests tasks without regressions.

---
*PR created automatically by Jules for task [17076542863697746543](https://jules.google.com/task/17076542863697746543) started by @haseeb-heaven*