### PR TITLE
🛡️ Sentinel: [HIGH] Fix unredacted exception logging

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2025-02-14 - Redact sensitive data from exceptions in Telegram
+
+**Vulnerability:** URL exceptions in `urllib.error.URLError` and generic exceptions are logged/printed unredacted when a request fails.
+**Learning:** Exception messages can include the URL or payload if they originate from networking libraries or unhandled application states. For Telegram, the token is embedded in the URL `https://api.telegram.org/bot<TOKEN>/sendMessage`. If an error occurs, the URL (with the token) might be printed to stdout.
+**Prevention:** Always wrap the exception object with `redact_sensitive()` before printing or logging it to prevent leaking secret tokens embedded in URLs.

--- a/gws_assistant/tools/telegram.py
+++ b/gws_assistant/tools/telegram.py
@@ -83,10 +83,10 @@ def send_telegram(message, context=None):
         print("Telegram message sent.")
         return True
     except urllib.error.URLError as e:
-        print(f"Error sending Telegram message: {e}")
+        print(f"Error sending Telegram message: {redact_sensitive(e)}")
         return False
     except Exception as e:
-        print(f"Exception sending Telegram message: {e}")
+        print(f"Exception sending Telegram message: {redact_sensitive(e)}")
         return False
 
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: URL exceptions in urllib.error.URLError and generic exceptions are logged/printed unredacted when a request fails.
🎯 Impact: Telegram bot token leakage in logs.
🔧 Fix: Wraps the exception object with `redact_sensitive()` before printing or logging it to prevent leaking secret tokens embedded in URLs.
✅ Verification: Tested unit tests for telegram functionality with `pytest tests/test_tools_telegram.py tests/test_telegram_script.py`.

---
*PR created automatically by Jules for task [15987743598472196244](https://jules.google.com/task/15987743598472196244) started by @haseeb-heaven*