### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection risk in subprocess

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - Fix subprocess shell=True vulnerability
+**Vulnerability:** subprocess.run uses shell=os.name == "nt" which can lead to command injection.
+**Learning:** Windows does not strictly require shell=True to execute binaries like sys.executable. Using shell=True with a command list can cause command injection vulnerabilities and triggers Bandit B602 alerts.
+**Prevention:** Explicitly pass shell=False across all platforms when invoking subprocess.run with a command list.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `subprocess.run` was conditionally using `shell=True` on Windows (`shell=os.name == "nt"`), which can lead to command injection.
🎯 Impact: Potential execution of arbitrary commands if any arguments injected into the command list contain shell metacharacters on Windows.
🔧 Fix: Changed `shell=os.name == "nt"` to `shell=False`, as Windows does not require a shell to execute binaries like `sys.executable`.
✅ Verification: Run `bandit` on the codebase to verify the B602 alert is resolved, and run unit tests for the framework runner to verify no loss of functionality.

---
*PR created automatically by Jules for task [11864041468981373177](https://jules.google.com/task/11864041468981373177) started by @haseeb-heaven*