### PR TITLE
⚡ Bolt: [performance improvement] Optimize string prefix/suffix checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - [Optimization of `startswith` and `endswith` checks]
+**Learning:** Generator expressions with `any()` for string prefix/suffix checks (e.g. `any(val.startswith(p) for p in iter)`) are about 10x slower than using C-optimized tuple matching `val.startswith(tuple_of_prefixes)`. The tuple must be statically defined or converted once, not on every call.
+**Action:** Replace `any(path.endswith(s) for s in list)` with `path.endswith(tuple)` and `any(val.startswith(p) for p in list)` with `val.startswith(tuple)` in hot paths like verification engine and resolver.

--- a/gws_assistant/execution/resolver.py
+++ b/gws_assistant/execution/resolver.py
@@ -575,7 +575,7 @@ class ResolverMixin:
 
                 # 2. If we resolved to a list, but we are a single-token placeholder
                 # (e.g. {{task-1.id}}), pick the first item.
-                singular_suffixes = [
+                singular_suffixes = (
                     ".id",
                     ".name",
                     ".url",
@@ -587,8 +587,8 @@ class ResolverMixin:
                     ".documentId",
                     ".fileId",
                     ".file_id",
-                ]
-                if isinstance(resolved, list) and resolved and any(path.endswith(s) for s in singular_suffixes):
+                )
+                if isinstance(resolved, list) and resolved and path.endswith(singular_suffixes):
                     self.logger.debug(f"DEBUG: Smart-unwrapping list result for '{path}' to first item.")
                     # We have a list. Check if we need to do the folder heuristic.
                     # Since resolved is likely just strings here (e.g. ['folder_id', 'doc_id']),

--- a/gws_assistant/verification_engine.py
+++ b/gws_assistant/verification_engine.py
@@ -1676,7 +1676,7 @@ class VerificationEngine:
     def _is_valid_drive_id(cls, value: str) -> bool:
         val_str = str(value)
         # Allow internal placeholders and specific recognized prefixes
-        if any(val_str.startswith(prefix) for prefix in ["sheet-", "doc-", "folder-", "file-", "evt-", "sent-", "$", "{{"]):
+        if val_str.startswith(("sheet-", "doc-", "folder-", "file-", "evt-", "sent-", "$", "{{")):
             return len(val_str) > 2
         # Regular Drive IDs are URL-safe base64 encoded (25-60 chars).
         # Allow: alphanumeric, hyphen, underscore, period, and equals padding.


### PR DESCRIPTION
💡 What: Replaced generator expressions using `any()` with C-optimized tuple matching for `startswith()` and `endswith()` string methods.
🎯 Why: Using `any(s.startswith(p) for p in lst)` is inherently slow in Python due to generator overhead and interpreted loop evaluation. Native tuple matching pushes the loop to C code.
📊 Impact: ~10x speedup for these specific string checks, reducing overhead during intense verification and resolving loops.
🔬 Measurement: Tested via a standalone benchmarking script (`test_perf.py`). `any()` with list takes ~2.08s for 1M iterations, whereas `startswith(tuple)` takes ~0.20s.

---
*PR created automatically by Jules for task [10968406815932217228](https://jules.google.com/task/10968406815932217228) started by @haseeb-heaven*