### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command Injection risk in subprocess execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-08-16 - Subprocess Command Injection on Windows
+**Vulnerability:** Found `shell=os.name == "nt"` being used in `subprocess.run(cmd, ...)` in `framework/task_runner.py`.
+**Learning:** Using `shell=True` (even conditionally on Windows) when passing a list of arguments is a command injection risk and flagged by Bandit (B602). Windows does not require `shell=True` to execute binaries like `sys.executable`.
+**Prevention:** Always use `shell=False` when calling `subprocess.run` with a command list, across all platforms.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `framework/task_runner.py` used `shell=os.name == "nt"` when invoking `subprocess.run` with a list of arguments.
🎯 Impact: A potential attacker could perform command injection if any un-escaped arguments are passed to the subprocess call on Windows platforms.
🔧 Fix: Hardcoded `shell=False` to safely pass the argument list directly without the shell overhead, effectively preventing command injection.
✅ Verification: Ran Bandit security scan to verify B602 is resolved. Also verified existing tests pass successfully.

---
*PR created automatically by Jules for task [16057239635375278908](https://jules.google.com/task/16057239635375278908) started by @haseeb-heaven*