### PR TITLE
🎨 Palette: Add primary button variants

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-17 - Button Variants
+**Learning:** Adding variant="primary" to key action buttons helps to distinguish primary actions from secondary actions, improving visual flow and usability.
+**Action:** Use variant="primary" for primary buttons like "Submit" or "Run" in Gradio.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -283,7 +283,7 @@ def create_interface() -> gr.Blocks:
                     placeholder="Paste the code from Google after signing in",
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", visible=False, variant="primary")
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to the main "Run" and "Authenticate" buttons in the Gradio interface.
🎯 Why: To visually distinguish the most important actions for users, improving usability and guiding interactions.
📸 Before/After: Before: Buttons had the default secondary styling. After: Primary buttons stand out with the primary theme color.
♿ Accessibility: Improved visual hierarchy and discoverability of primary actions for all users.

---
*PR created automatically by Jules for task [348108901840932492](https://jules.google.com/task/348108901840932492) started by @haseeb-heaven*