### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection vulnerability in subprocess call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-08-17 - Command Injection Risk in Subprocess
+**Vulnerability:** Found `subprocess.run(..., shell=os.name == "nt")` in `framework/task_runner.py` which passes `shell=True` on Windows.
+**Learning:** Using `shell=True` (even conditionally based on OS) when passing a command list (like `[sys.executable, "-m", ...]`) is generally unnecessary and creates a potential shell injection vector if any of the array elements were to incorporate unsanitized input. Windows doesn't need `shell=True` to execute `sys.executable`.
+**Prevention:** Always use `shell=False` for executing explicit binaries/modules via a command list, unless shell builtins are specifically required.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `subprocess.run` was using `shell=os.name == "nt"`, allowing potential command injection vectors on Windows if any elements of the command list contained unsanitized input.
🎯 Impact: A malicious actor could inject shell commands through environmental or dynamically generated variables passed into the `cmd` argument, executing arbitrary code with the permissions of the application.
🔧 Fix: Explicitly enforced `shell=False` for executing explicit binaries/modules, completely neutralizing the injection vector. Added Sentinel journal logging the vulnerability and prevention pattern.
✅ Verification: Tests passing successfully via pytest isolated runner, ensuring framework operations still succeed safely.

---
*PR created automatically by Jules for task [3531133915129043307](https://jules.google.com/task/3531133915129043307) started by @haseeb-heaven*