### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix Command Injection Vulnerability in task_runner

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-24 - Remove shell=os.name == "nt" from subprocess.run
+**Vulnerability:** Found `subprocess.run(..., shell=os.name == "nt")` in `framework/task_runner.py`, which evaluates to `shell=True` on Windows.
+**Learning:** `shell=True` is not strictly required on Windows to run executables like `sys.executable` or `pytest`. It introduces a Command Injection vulnerability (Bandit B602 alert) if arguments are not properly sanitized.
+**Prevention:** Always use `shell=False` across all platforms for `subprocess.run` with list arguments to prevent Command Injection, ensuring security without sacrificing functionality.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `subprocess.run` was called with `shell=os.name == "nt"`, which evaluates to `True` on Windows, creating a Command Injection risk (Bandit B602).
🎯 **Impact:** If arguments were unsanitized, an attacker could execute arbitrary shell commands on Windows platforms.
🔧 **Fix:** Changed `shell=os.name == "nt"` to `shell=False`. Windows does not require `shell=True` to execute binaries like `sys.executable`.
✅ **Verification:** Verified with Bandit and ran test suite (`pytest tests/test_runner.py`).

---
*PR created automatically by Jules for task [6702500250889817008](https://jules.google.com/task/6702500250889817008) started by @haseeb-heaven*