### PR TITLE
🎨 Palette: Improve Gradio UI interaction and accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Primary Buttons and Enter-key Submission in Gradio
+**Learning:** Users naturally press Enter after pasting tokens or long strings. Additionally, primary actions (like authentication or running tasks) blend in with secondary actions without visual distinction.
+**Action:** Use `variant="primary"` on primary `gr.Button` elements, bind `.submit()` events to `gr.Textbox` inputs to allow Enter-key submissions, and use `max_lines=1` on token textboxes to prevent awkward layout stretching.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
+                    max_lines=1,
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +304,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)
@@ -376,6 +377,18 @@ def create_interface() -> gr.Blocks:
                 submit_auth_button,
                 regenerate_url_button,
                 auth_message,
+                auth_message
+            ]
+        )
+
+        auth_code_input.submit(
+            fn=on_auth_submit,
+            inputs=[client_config_state, auth_code_input],
+            outputs=[
+                credentials_file_state,
+                auth_status,
+                auth_code_input,
+                regenerate_url_button,
                 auth_message
             ]
         )


### PR DESCRIPTION
💡 What: Added `variant="primary"` to main action buttons, limited auth token input to 1 line, and enabled Enter-key submission for auth codes.
🎯 Why: Makes the UI more intuitive by differentiating primary actions from secondary ones and supporting natural keyboard usage.
📸 Before/After: Visual distinction on Run/Authenticate buttons. Token input no longer expands awkwardly.
♿ Accessibility: Better keyboard support via `.submit()` binding on textboxes.

---
*PR created automatically by Jules for task [13578570230886797859](https://jules.google.com/task/13578570230886797859) started by @haseeb-heaven*