### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection vulnerability in subprocess call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Prevent Command Injection in subprocess calls
+**Vulnerability:** Use of `shell=os.name == "nt"` in `subprocess.run` with a command list.
+**Learning:** `shell=True` on Windows with a list of arguments allows potential command injection. Bandit flags this (B602). With a command list, Windows does not require `shell=True` to execute binaries like `sys.executable`.
+**Prevention:** Always use `shell=False` across all platforms when passing a command list to `subprocess.run` to prevent command injection vulnerabilities.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,8 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                # Security: Always use shell=False with a command list to prevent command injection (Bandit B602)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
* 🚨 Severity: CRITICAL
* 💡 Vulnerability: `subprocess.run` was called with `shell=True` on Windows using a command list, which exposes the application to command injection (Bandit rule B602).
* 🎯 Impact: If the `cmd` arguments are constructed from untrusted input, arbitrary shell commands could be executed on Windows environments.
* 🔧 Fix: Always passed `shell=False` to `subprocess.run` since the arguments are securely provided as a list and do not require shell execution to run `sys.executable`.
* ✅ Verification: Tested running the `task_runner` locally and verified tests pass. Tested and verified that Bandit scan no longer flags this line.

---
*PR created automatically by Jules for task [11698746888439139786](https://jules.google.com/task/11698746888439139786) started by @haseeb-heaven*