### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection vulnerability in subprocess call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Fix command injection vulnerability in task runner
+**Vulnerability:** Found `subprocess.run` with `shell=os.name == "nt"` in `framework/task_runner.py`
+**Learning:** `shell=True` (which evaluating `os.name == "nt"` is on Windows) on `subprocess.run` can lead to command injection if arguments are unsanitized. Specifically, executing Python scripts or binaries on Windows does not actually require `shell=True`, and using it poses an unnecessary risk.
+**Prevention:** Always use `shell=False` across all platforms unless there's a strict, necessary requirement to run shell built-ins or use pipes. For executing Python modules (like `sys.executable -m pytest`), `shell=False` is entirely sufficient and safer.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `subprocess.run` was executing with `shell=os.name == "nt"`, leaving the application vulnerable to command injection on Windows platforms if arguments are unsanitized.
🎯 Impact: High - arbitrary command injection via shell metacharacters could lead to full system compromise.
🔧 Fix: Set `shell=False` explicitly for the `subprocess.run` command, as Windows doesn't require `shell=True` to execute `sys.executable`. Also created Sentinel journal entry to log this finding.
✅ Verification: Ran bandit and confirmed the B404/B602 HIGH severity vulnerability is mitigated. Tests pass.

---
*PR created automatically by Jules for task [14625857718667644416](https://jules.google.com/task/14625857718667644416) started by @haseeb-heaven*