### PR TITLE
🎨 Palette: Add primary button variants

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-20 - Adding primary button variants in Gradio
+**Learning:** In Gradio applications, setting `variant="primary"` on key buttons helps distinguish primary actions (like 'Run' or 'Authenticate') from secondary actions (like 'Clear'), improving visual hierarchy and making it more intuitive for users to identify the main call to action.
+**Action:** Always check if main action buttons in Gradio have the `variant="primary"` attribute and add them if they are missing.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -303,7 +303,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to the main "Run" button in the Gradio web UI.
🎯 Why: To create a clearer visual hierarchy, making the primary action stand out compared to secondary actions like "Clear".
📸 Before/After: Before, both buttons looked identical. After, the Run button has a distinctive primary color.
♿ Accessibility: Improves visual clarity and reduces cognitive load by distinguishing main actions.

---
*PR created automatically by Jules for task [2907547482992034823](https://jules.google.com/task/2907547482992034823) started by @haseeb-heaven*