### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command Injection risk in subprocess

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-08-21 - Command Injection Risk with shell=True on Windows
+**Vulnerability:** Invoking `subprocess.run` with `shell=os.name == "nt"` evaluates to `shell=True` on Windows environments, which introduces a Command Injection vulnerability (CWE-78) when executing commands, resulting in a Bandit B602 warning.
+**Learning:** The conditional was likely added under the false assumption that Windows strictly requires `shell=True` to execute binaries or scripts with `subprocess`. However, Windows can safely execute list-format commands (like `sys.executable` with arguments) using `shell=False`.
+**Prevention:** Always explicitly pass `shell=False` to `subprocess.run()` across all platforms to prevent Command Injection vulnerabilities.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Command Injection risk (CWE-78) due to `shell=os.name == "nt"` evaluating to `shell=True` on Windows.
🎯 Impact: If arguments were improperly sanitized, arbitrary shell commands could be executed on Windows systems.
🔧 Fix: Changed `shell=os.name == "nt"` to `shell=False`. Windows properly handles command lists without `shell=True`.
✅ Verification: Run Bandit and ensure no B602 warnings are raised for this file. Test execution via `pytest tests/test_runner.py` succeeds.

---
*PR created automatically by Jules for task [14051500335502830938](https://jules.google.com/task/14051500335502830938) started by @haseeb-heaven*