### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Telegram token leakage in exceptions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-10-24 - Secret Leakage via URL Exceptions
+**Vulnerability:** Telegram API token was being leaked to logs when `urllib.error.URLError` occurred, because the token is embedded in the requested URL (which is printed in the exception message).
+**Learning:** Standard HTTP/URL exception messages often include the requested URL. If the URL contains sensitive tokens or credentials in the path, simply printing the exception exposes those secrets.
+**Prevention:** Always wrap HTTP/URL exception objects with a redaction function (like `redact_sensitive()`) before printing or logging them to prevent embedded secrets from leaking.

--- a/gws_assistant/tools/telegram.py
+++ b/gws_assistant/tools/telegram.py
@@ -83,10 +83,10 @@ def send_telegram(message, context=None):
         print("Telegram message sent.")
         return True
     except urllib.error.URLError as e:
-        print(f"Error sending Telegram message: {e}")
+        print(redact_sensitive(f"Error sending Telegram message: {e}"))
         return False
     except Exception as e:
-        print(f"Exception sending Telegram message: {e}")
+        print(redact_sensitive(f"Exception sending Telegram message: {e}"))
         return False
 
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: When `urllib.error.URLError` or `Exception` occurs during the Telegram API call, the exception object contains the URL. Since the URL structure is `https://api.telegram.org/bot{token}/sendMessage`, printing the exception directly leaks the API token to logs.
🎯 Impact: Attackers or unauthorized users with access to logs could extract the Telegram bot token and hijack the bot or send unauthorized messages.
🔧 Fix: Wrapped the exception string in `redact_sensitive()` before printing to ensure the token is masked in the output.
✅ Verification: Ensured tests pass successfully and any exceptions logged are sanitized using `redact_sensitive()`.

---
*PR created automatically by Jules for task [17324287096587986218](https://jules.google.com/task/17324287096587986218) started by @haseeb-heaven*