### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection vulnerability in subprocess call

### DIFF
--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH\n💡 Vulnerability: `subprocess.run` in `framework/task_runner.py` was invoked with `shell=os.name == "nt"`, introducing a command injection risk on Windows environments.\n🎯 Impact: If the `cmd` list contains user-controlled input, passing it to `shell=True` can allow arbitrary shell command execution, bypassing security controls.\n🔧 Fix: Changed `shell=os.name == "nt"` to `shell=False`. Windows does not require `shell=True` for executing standard binaries like `sys.executable`.\n✅ Verification: Ran `bandit` and verified the B602 alert is resolved. Ran `pytest tests/test_runner.py` and it passed.

---
*PR created automatically by Jules for task [2337682466959796804](https://jules.google.com/task/2337682466959796804) started by @haseeb-heaven*