### PR TITLE
🎨 Palette: Add primary variants to key actions and prevent token input stretching

### DIFF
--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
+                    max_lines=1,
                     visible=False
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +304,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)


### PR DESCRIPTION
💡 What: Added `variant="primary"` to the "Run" and "Authenticate" buttons, and `max_lines=1` to the authorization code input.
🎯 Why: Primary actions should be visually distinct from secondary actions to guide user interaction. Restricting long token inputs to a single line prevents awkward layout stretching.
📸 Before/After: Visual hierarchy is improved with highlighted primary buttons, and token pasting maintains a stable UI layout.
♿ Accessibility: Better visual contrast and clear indication of primary actions for keyboard/mouse users.

---
*PR created automatically by Jules for task [14115746681652127942](https://jules.google.com/task/14115746681652127942) started by @haseeb-heaven*