### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command Injection Risk in task_runner

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-10-24 - Fix subprocess shell=True vulnerability
+**Vulnerability:** subprocess.run was called with shell=os.name == "nt" for a list of arguments.
+**Learning:** Windows does not strictly require shell=True to execute binaries like sys.executable. Passing shell=True with an argument list can lead to command injection if elements aren't properly escaped.
+**Prevention:** Always use shell=False across all platforms when passing a list of arguments to subprocess.run.

--- a/framework/task_runner.py
+++ b/framework/task_runner.py
@@ -75,7 +75,7 @@ class TaskRunner:
             cmd = [sys.executable, "-m", "pytest", "-v", "-m", marker_expr]
 
             try:
-                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=os.name == "nt", timeout=60)
+                process = subprocess.run(cmd, capture_output=True, text=True, env=env, shell=False, timeout=60)
             except subprocess.TimeoutExpired:
                 self.status = "FAILED"
                 logger.warning(f"Runner {self.agent_id} ({self.service}) FAILED: Timeout Expired")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: subprocess.run was called with `shell=os.name == "nt"` which is flagged by Bandit (B602) because it opens up the possibility for command injection.
🎯 Impact: A malicious actor could potentially inject arbitrary shell commands on Windows by manipulating arguments to `subprocess.run`.
🔧 Fix: Explicitly set `shell=False` for all platforms. Windows can execute binaries like `sys.executable` without `shell=True`.
✅ Verification: Ran `bandit` to verify the B602 warning is gone, and ran `pytest tests/test_runner.py` to ensure normal execution works.

---
*PR created automatically by Jules for task [12042082962026721773](https://jules.google.com/task/12042082962026721773) started by @haseeb-heaven*