### PR TITLE
⚡ Bolt: Optimize startswith checks for performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-08-26 - [Optimize startswith with Tuple Matching]
+**Learning:** Using `startswith` with a generator expression (e.g. `any(s.startswith(p) for p in prefixes)`) or chaining multiple `startswith` calls with `or` creates unnecessary overhead in Python. Passing a static literal tuple directly to `startswith` (e.g. `s.startswith(tuple_of_prefixes)`) utilizes the C-optimized CPython implementation and is much faster.
+**Action:** Always use tuple arguments for `startswith` and `endswith` instead of generator expressions or multiple `or` conditions when checking against multiple static prefixes/suffixes.

--- a/gws_assistant/langchain_agent.py
+++ b/gws_assistant/langchain_agent.py
@@ -482,7 +482,8 @@ def _invoke_with_backoff(
             return None
 
         try:
-            if model_name.startswith("groq/") or model_name.startswith("openrouter/") or model_name.startswith("google/") or model_name.startswith("gemini/") or model_name.startswith("cerebras/"):
+            # ⚡ Bolt: Replaced long boolean or chain with C-optimized tuple matching for startswith to improve performance
+            if model_name.startswith(("groq/", "openrouter/", "google/", "gemini/", "cerebras/")):
                 # Groq's tool-calling implementation via LangChain's with_structured_output
                 # is currently unstable (tool_choice errors). We bypass it and call LiteLLM
                 # directly with a JSON instruction.

--- a/gws_assistant/verification_engine.py
+++ b/gws_assistant/verification_engine.py
@@ -1676,7 +1676,8 @@ class VerificationEngine:
     def _is_valid_drive_id(cls, value: str) -> bool:
         val_str = str(value)
         # Allow internal placeholders and specific recognized prefixes
-        if any(val_str.startswith(prefix) for prefix in ["sheet-", "doc-", "folder-", "file-", "evt-", "sent-", "$", "{{"]):
+        # ⚡ Bolt: Replaced generator expression with C-optimized tuple matching for startswith to improve performance
+        if val_str.startswith(("sheet-", "doc-", "folder-", "file-", "evt-", "sent-", "$", "{{")):
             return len(val_str) > 2
         # Regular Drive IDs are URL-safe base64 encoded (25-60 chars).
         # Allow: alphanumeric, hyphen, underscore, period, and equals padding.


### PR DESCRIPTION
💡 What: Replaced generator expressions and multiple boolean `or` conditions using `startswith` with static literal tuple matching.
🎯 Why: Generator expressions like `any(val.startswith(p) for p in iter)` and long chains of `or` evaluate slowly in Python. Passing a tuple of prefixes to `startswith` utilizes CPython's C-optimized tuple matching, which has significantly less overhead.
📊 Impact: Reduces overhead and executes faster, especially since these validation functions can be called frequently during verification loops.
🔬 Measurement: The micro-benchmark for `startswith` tuple matching shows it is faster than both generator expressions and chained `or` conditions in CPython.

---
*PR created automatically by Jules for task [7048187958808612092](https://jules.google.com/task/7048187958808612092) started by @haseeb-heaven*