### PR TITLE
🎨 Palette: Add primary button variants and enter-key submission to Gradio UI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Improve Gradio Buttons and Textbox UX
+**Learning:** Gradio UI default secondary buttons blend into the background, missing the primary call to actions (like 'Authenticate' or 'Run'). Additionally, placing single-token textboxes (like the Auth code input) without restricting `max_lines` causes awkward stretching if users accidentally hit 'Enter' inside the box, which ruins form alignment.
+**Action:** Always set `variant="primary"` for main submission actions (like `.click()` triggers) in Gradio interfaces to naturally guide the user's eye. Restrict single-token input fields with `max_lines=1` and bind them with `.submit()` events so power-users can submit straight from the keyboard without breaking the visual layout.

--- a/gws_assistant/gradio_app.py
+++ b/gws_assistant/gradio_app.py
@@ -281,9 +281,10 @@ def create_interface() -> gr.Blocks:
                 auth_code_input = gr.Textbox(
                     label="Paste Authorization Code",
                     placeholder="Paste the code from Google after signing in",
-                    visible=False
+                    visible=False,
+                    max_lines=1
                 )
-                submit_auth_button = gr.Button("Authenticate", visible=False)
+                submit_auth_button = gr.Button("Authenticate", variant="primary", visible=False)
                 regenerate_url_button = gr.Button("Generate New Auth URL", visible=False)
 
             auth_message = gr.Textbox(
@@ -303,7 +304,7 @@ def create_interface() -> gr.Blocks:
                 placeholder="Example: List recent Gmail messages and show details",
             )
         with gr.Row():
-            run_button = gr.Button("Run")
+            run_button = gr.Button("Run", variant="primary")
             clear_button = gr.Button("Clear")
         output = gr.Textbox(label="Result", lines=18)
         plan_preview = gr.Textbox(label="Planned Tasks", lines=8)
@@ -387,6 +388,18 @@ def create_interface() -> gr.Blocks:
         )
 
         submit_auth_button.click(
+            fn=on_auth_submit,
+            inputs=[client_config_state, auth_code_input],
+            outputs=[
+                credentials_file_state,
+                auth_status,
+                auth_code_input,
+                regenerate_url_button,
+                auth_message
+            ]
+        )
+
+        auth_code_input.submit(
             fn=on_auth_submit,
             inputs=[client_config_state, auth_code_input],
             outputs=[


### PR DESCRIPTION
💡 What: Added `variant="primary"` to main action buttons, set `max_lines=1` for auth code input to prevent layout stretching, and added enter-key `.submit()` support for auth code.
🎯 Why: To make primary actions more obvious to the user, ensure text inputs don't stretch awkwardly for single-line tokens, and enable a smoother keyboard-only authentication flow.
📸 Before/After: Visual update on button styling and layout.
♿ Accessibility: Improved keyboard navigation flow for the auth code input by avoiding need to tab to "Authenticate" button.

---
*PR created automatically by Jules for task [12422851086851029363](https://jules.google.com/task/12422851086851029363) started by @haseeb-heaven*